### PR TITLE
Add Ably events across all domains

### DIFF
--- a/src/main/java/org/phong/horizon/admin/logentry/events/CreateLogEntryEvent.java
+++ b/src/main/java/org/phong/horizon/admin/logentry/events/CreateLogEntryEvent.java
@@ -1,16 +1,28 @@
 package org.phong.horizon.admin.logentry.events;
 
 import lombok.Getter;
+import org.phong.horizon.ably.event.AblyPublishableEvent;
 import org.phong.horizon.admin.logentry.dtos.CreateLogEntryRequest;
+import org.phong.horizon.admin.logentry.utils.LogEntryChannelNames;
 import org.springframework.context.ApplicationEvent;
 
 @Getter
-public class CreateLogEntryEvent extends ApplicationEvent {
+public class CreateLogEntryEvent extends ApplicationEvent implements AblyPublishableEvent {
     private final CreateLogEntryRequest createLogEntryRequest;
 
     public CreateLogEntryEvent(Object source, CreateLogEntryRequest createLogEntryRequest) {
         super(source);
         this.createLogEntryRequest = createLogEntryRequest;
+    }
+
+    @Override
+    public String getChannelName() {
+        return LogEntryChannelNames.adminLogs();
+    }
+
+    @Override
+    public String getEventName() {
+        return "admin.log.created";
     }
 }
 

--- a/src/main/java/org/phong/horizon/admin/logentry/utils/LogEntryChannelNames.java
+++ b/src/main/java/org/phong/horizon/admin/logentry/utils/LogEntryChannelNames.java
@@ -1,0 +1,12 @@
+package org.phong.horizon.admin.logentry.utils;
+
+public final class LogEntryChannelNames {
+    private LogEntryChannelNames() {}
+
+    /**
+     * Channel for admin log events
+     */
+    public static String adminLogs() {
+        return "admin.logs";
+    }
+}

--- a/src/main/java/org/phong/horizon/admin/notification/events/CreateAdminNotificationEvent.java
+++ b/src/main/java/org/phong/horizon/admin/notification/events/CreateAdminNotificationEvent.java
@@ -1,16 +1,28 @@
 package org.phong.horizon.admin.notification.events;
 
 import lombok.Getter;
+import org.phong.horizon.ably.event.AblyPublishableEvent;
 import org.phong.horizon.admin.notification.infrastructure.dtos.CreateAdminNotification;
+import org.phong.horizon.admin.notification.utils.AdminNotificationChannelNames;
 import org.springframework.context.ApplicationEvent;
 
 @Getter
-public class CreateAdminNotificationEvent extends ApplicationEvent {
+public class CreateAdminNotificationEvent extends ApplicationEvent implements AblyPublishableEvent {
     private final CreateAdminNotification createAdminNotificationDto;
 
     public CreateAdminNotificationEvent(Object source, CreateAdminNotification createAdminNotificationDto) {
         super(source);
         this.createAdminNotificationDto = createAdminNotificationDto;
+    }
+
+    @Override
+    public String getChannelName() {
+        return AdminNotificationChannelNames.adminNotifications();
+    }
+
+    @Override
+    public String getEventName() {
+        return "admin.notification.created";
     }
 }
 

--- a/src/main/java/org/phong/horizon/admin/notification/utils/AdminNotificationChannelNames.java
+++ b/src/main/java/org/phong/horizon/admin/notification/utils/AdminNotificationChannelNames.java
@@ -1,0 +1,12 @@
+package org.phong.horizon.admin.notification.utils;
+
+public final class AdminNotificationChannelNames {
+    private AdminNotificationChannelNames() {}
+
+    /**
+     * Global channel for admin notifications
+     */
+    public static String adminNotifications() {
+        return "admin.notifications";
+    }
+}

--- a/src/main/java/org/phong/horizon/comment/events/CommentMentionCreatedEvent.java
+++ b/src/main/java/org/phong/horizon/comment/events/CommentMentionCreatedEvent.java
@@ -1,13 +1,15 @@
 package org.phong.horizon.comment.events;
 
 import lombok.Getter;
+import org.phong.horizon.ably.event.AblyPublishableEvent;
+import org.phong.horizon.comment.utils.CommentChannelNames;
 import org.springframework.context.ApplicationEvent;
 
 import java.util.Map;
 import java.util.UUID;
 
 @Getter
-public class CommentMentionCreatedEvent extends ApplicationEvent {
+public class CommentMentionCreatedEvent extends ApplicationEvent implements AblyPublishableEvent {
     private final UUID commentId;
     private final UUID postId;
     private final String authorUsername;
@@ -29,5 +31,15 @@ public class CommentMentionCreatedEvent extends ApplicationEvent {
         this.authorId = authorId;
         this.content = content;
         this.mapUsernameToUserId = mapUsernameToUserId;
+    }
+
+    @Override
+    public String getChannelName() {
+        return CommentChannelNames.comment(commentId);
+    }
+
+    @Override
+    public String getEventName() {
+        return "comment.mention.created";
     }
 }

--- a/src/main/java/org/phong/horizon/comment/events/CommentMentionDeletedEvent.java
+++ b/src/main/java/org/phong/horizon/comment/events/CommentMentionDeletedEvent.java
@@ -1,13 +1,15 @@
 package org.phong.horizon.comment.events;
 
 import lombok.Getter;
+import org.phong.horizon.ably.event.AblyPublishableEvent;
+import org.phong.horizon.comment.utils.CommentChannelNames;
 import org.springframework.context.ApplicationEvent;
 
 import java.util.List;
 import java.util.UUID;
 
 @Getter
-public class CommentMentionDeletedEvent extends ApplicationEvent {
+public class CommentMentionDeletedEvent extends ApplicationEvent implements AblyPublishableEvent {
     private final UUID commentId;
     private final List<UUID> mentionUserIds;
 
@@ -15,5 +17,15 @@ public class CommentMentionDeletedEvent extends ApplicationEvent {
         super(source);
         this.commentId = commentId;
         this.mentionUserIds = mentionUserIds;
+    }
+
+    @Override
+    public String getChannelName() {
+        return CommentChannelNames.comment(commentId);
+    }
+
+    @Override
+    public String getEventName() {
+        return "comment.mention.deleted";
     }
 }

--- a/src/main/java/org/phong/horizon/follow/events/UserFollowedEvent.java
+++ b/src/main/java/org/phong/horizon/follow/events/UserFollowedEvent.java
@@ -1,12 +1,14 @@
 package org.phong.horizon.follow.events;
 
 import lombok.Getter;
+import org.phong.horizon.ably.event.AblyPublishableEvent;
+import org.phong.horizon.follow.utils.FollowChannelNames;
 import org.springframework.context.ApplicationEvent;
 
 import java.util.UUID;
 
 @Getter
-public class UserFollowedEvent extends ApplicationEvent {
+public class UserFollowedEvent extends ApplicationEvent implements AblyPublishableEvent {
     private final String followerUsername;
     private final String followedUsername;
     private final UUID followedUserId;
@@ -22,5 +24,15 @@ public class UserFollowedEvent extends ApplicationEvent {
         this.followedUsername = followedUsername;
         this.followedUserId = followedUserId;
         this.followerUserId = followerUserId;
+    }
+
+    @Override
+    public String getChannelName() {
+        return FollowChannelNames.userFollowers(followedUserId);
+    }
+
+    @Override
+    public String getEventName() {
+        return "user.followed";
     }
 }

--- a/src/main/java/org/phong/horizon/follow/events/UserUnFollowedEvent.java
+++ b/src/main/java/org/phong/horizon/follow/events/UserUnFollowedEvent.java
@@ -1,13 +1,15 @@
 package org.phong.horizon.follow.events;
 
 import lombok.Getter;
+import org.phong.horizon.ably.event.AblyPublishableEvent;
+import org.phong.horizon.follow.utils.FollowChannelNames;
 import org.springframework.context.ApplicationEvent;
 
 import java.util.UUID;
 
 //websocket later
 @Getter
-public class UserUnFollowedEvent extends ApplicationEvent {
+public class UserUnFollowedEvent extends ApplicationEvent implements AblyPublishableEvent {
     private final UUID followerUserId;
     private final UUID followedUserId;
     private final String followerUsername;
@@ -23,5 +25,15 @@ public class UserUnFollowedEvent extends ApplicationEvent {
         this.followedUserId = followedUserId;
         this.followerUsername = followerUsername;
         this.followedUsername = followedUsername;
+    }
+
+    @Override
+    public String getChannelName() {
+        return FollowChannelNames.userFollowers(followedUserId);
+    }
+
+    @Override
+    public String getEventName() {
+        return "user.unfollowed";
     }
 }

--- a/src/main/java/org/phong/horizon/follow/utils/FollowChannelNames.java
+++ b/src/main/java/org/phong/horizon/follow/utils/FollowChannelNames.java
@@ -1,0 +1,14 @@
+package org.phong.horizon.follow.utils;
+
+import java.util.UUID;
+
+public final class FollowChannelNames {
+    private FollowChannelNames() {}
+
+    /**
+     * Channel for events when a user gains or loses followers
+     */
+    public static String userFollowers(UUID userId) {
+        return "followers." + userId;
+    }
+}

--- a/src/main/java/org/phong/horizon/historyactivity/events/CreateHistoryLogEvent.java
+++ b/src/main/java/org/phong/horizon/historyactivity/events/CreateHistoryLogEvent.java
@@ -1,15 +1,27 @@
 package org.phong.horizon.historyactivity.events;
 
 import lombok.Getter;
+import org.phong.horizon.ably.event.AblyPublishableEvent;
 import org.phong.horizon.historyactivity.dtos.CreateHistoryActivity;
+import org.phong.horizon.historyactivity.utils.HistoryChannelNames;
 import org.springframework.context.ApplicationEvent;
 
 @Getter
-public class CreateHistoryLogEvent extends ApplicationEvent {
+public class CreateHistoryLogEvent extends ApplicationEvent implements AblyPublishableEvent {
     private final CreateHistoryActivity request;
 
     public CreateHistoryLogEvent(Object source, CreateHistoryActivity request) {
         super(source);
         this.request = request;
+    }
+
+    @Override
+    public String getChannelName() {
+        return HistoryChannelNames.userHistory(request.userId());
+    }
+
+    @Override
+    public String getEventName() {
+        return "history.created";
     }
 }

--- a/src/main/java/org/phong/horizon/historyactivity/utils/HistoryChannelNames.java
+++ b/src/main/java/org/phong/horizon/historyactivity/utils/HistoryChannelNames.java
@@ -1,0 +1,14 @@
+package org.phong.horizon.historyactivity.utils;
+
+import java.util.UUID;
+
+public final class HistoryChannelNames {
+    private HistoryChannelNames() {}
+
+    /**
+     * Channel for a user's history log events
+     */
+    public static String userHistory(UUID userId) {
+        return "history." + userId;
+    }
+}

--- a/src/main/java/org/phong/horizon/notification/events/CreateNotificationEvent.java
+++ b/src/main/java/org/phong/horizon/notification/events/CreateNotificationEvent.java
@@ -1,13 +1,15 @@
 package org.phong.horizon.notification.events;
 
 import lombok.Getter;
+import org.phong.horizon.ably.event.AblyPublishableEvent;
 import org.phong.horizon.notification.dtos.CreateNotificationRequest;
+import org.phong.horizon.notification.utils.NotificationChannelNames;
 import org.springframework.context.ApplicationEvent;
 
 import java.util.UUID;
 
 @Getter
-public class CreateNotificationEvent extends ApplicationEvent {
+public class CreateNotificationEvent extends ApplicationEvent implements AblyPublishableEvent {
     private final UUID senderUserId;
     private final CreateNotificationRequest request;
 
@@ -15,5 +17,15 @@ public class CreateNotificationEvent extends ApplicationEvent {
         super(source);
         this.senderUserId = senderUserId;
         this.request = request;
+    }
+
+    @Override
+    public String getChannelName() {
+        return NotificationChannelNames.notification(request.getRecipientUserId());
+    }
+
+    @Override
+    public String getEventName() {
+        return "notification.created";
     }
 }

--- a/src/main/java/org/phong/horizon/notification/utils/NotificationChannelNames.java
+++ b/src/main/java/org/phong/horizon/notification/utils/NotificationChannelNames.java
@@ -1,0 +1,14 @@
+package org.phong.horizon.notification.utils;
+
+import java.util.UUID;
+
+public final class NotificationChannelNames {
+    private NotificationChannelNames() {}
+
+    /**
+     * Channel for notifications targeted to a specific user
+     */
+    public static String notification(UUID userId) {
+        return "notifications." + userId;
+    }
+}

--- a/src/main/java/org/phong/horizon/post/events/PostCreatedEvent.java
+++ b/src/main/java/org/phong/horizon/post/events/PostCreatedEvent.java
@@ -1,12 +1,14 @@
 package org.phong.horizon.post.events;
 
 import lombok.Getter;
+import org.phong.horizon.ably.event.AblyPublishableEvent;
+import org.phong.horizon.post.utils.PostChannelNames;
 import org.springframework.context.ApplicationEvent;
 
 import java.util.UUID;
 
 @Getter
-public class PostCreatedEvent extends ApplicationEvent {
+public class PostCreatedEvent extends ApplicationEvent implements AblyPublishableEvent {
     private final UUID postId;
     private final UUID userId;
     private final String title;
@@ -18,5 +20,15 @@ public class PostCreatedEvent extends ApplicationEvent {
         this.userId = userId;
         this.title = title;
         this.content = content;
+    }
+
+    @Override
+    public String getChannelName() {
+        return PostChannelNames.posts();
+    }
+
+    @Override
+    public String getEventName() {
+        return "post.created";
     }
 }

--- a/src/main/java/org/phong/horizon/post/events/PostDeletedEvent.java
+++ b/src/main/java/org/phong/horizon/post/events/PostDeletedEvent.java
@@ -1,12 +1,14 @@
 package org.phong.horizon.post.events;
 
 import lombok.Getter;
+import org.phong.horizon.ably.event.AblyPublishableEvent;
+import org.phong.horizon.post.utils.PostChannelNames;
 import org.springframework.context.ApplicationEvent;
 
 import java.util.UUID;
 
 @Getter
-public class PostDeletedEvent extends ApplicationEvent {
+public class PostDeletedEvent extends ApplicationEvent implements AblyPublishableEvent {
     private final UUID postId;
     private final UUID userId;
 
@@ -14,5 +16,15 @@ public class PostDeletedEvent extends ApplicationEvent {
         super(source);
         this.postId = postId;
         this.userId = userId;
+    }
+
+    @Override
+    public String getChannelName() {
+        return PostChannelNames.post(postId);
+    }
+
+    @Override
+    public String getEventName() {
+        return "post.deleted";
     }
 }

--- a/src/main/java/org/phong/horizon/post/events/PostUpdatedEvent.java
+++ b/src/main/java/org/phong/horizon/post/events/PostUpdatedEvent.java
@@ -1,14 +1,16 @@
 package org.phong.horizon.post.events;
 
 import lombok.Getter;
+import org.phong.horizon.ably.event.AblyPublishableEvent;
 import org.phong.horizon.core.dtos.FieldValueChange;
+import org.phong.horizon.post.utils.PostChannelNames;
 import org.springframework.context.ApplicationEvent;
 
 import java.util.Map;
 import java.util.UUID;
 
 @Getter
-public class PostUpdatedEvent extends ApplicationEvent {
+public class PostUpdatedEvent extends ApplicationEvent implements AblyPublishableEvent {
     private final UUID postId;
     private final UUID userId;
     private final String caption;
@@ -31,5 +33,15 @@ public class PostUpdatedEvent extends ApplicationEvent {
         this.additionalInfo = additionalInfo;
         this.userAgent = userAgent;
         this.clientIp = clientIp;
+    }
+
+    @Override
+    public String getChannelName() {
+        return PostChannelNames.post(postId);
+    }
+
+    @Override
+    public String getEventName() {
+        return "post.updated";
     }
 }

--- a/src/main/java/org/phong/horizon/post/subdomain/category/events/PostCategoryUpdate.java
+++ b/src/main/java/org/phong/horizon/post/subdomain/category/events/PostCategoryUpdate.java
@@ -3,7 +3,9 @@ package org.phong.horizon.post.subdomain.category.events;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.experimental.FieldDefaults;
+import org.phong.horizon.ably.event.AblyPublishableEvent;
 import org.phong.horizon.core.dtos.FieldValueChange;
+import org.phong.horizon.post.subdomain.category.utils.PostCategoryChannelNames;
 import org.springframework.context.ApplicationEvent;
 
 import java.util.Map;
@@ -11,7 +13,7 @@ import java.util.UUID;
 
 @Getter
 @FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
-public class PostCategoryUpdate extends ApplicationEvent {
+public class PostCategoryUpdate extends ApplicationEvent implements AblyPublishableEvent {
     String categoryName;
     Map<String, FieldValueChange> additionalInfo;
     String userAgent;
@@ -26,5 +28,15 @@ public class PostCategoryUpdate extends ApplicationEvent {
         this.userAgent = userAgent;
         this.clientIp = clientIp;
         this.userId = userId;
+    }
+
+    @Override
+    public String getChannelName() {
+        return PostCategoryChannelNames.postCategories();
+    }
+
+    @Override
+    public String getEventName() {
+        return "post.category.updated";
     }
 }

--- a/src/main/java/org/phong/horizon/post/subdomain/category/utils/PostCategoryChannelNames.java
+++ b/src/main/java/org/phong/horizon/post/subdomain/category/utils/PostCategoryChannelNames.java
@@ -1,0 +1,12 @@
+package org.phong.horizon.post.subdomain.category.utils;
+
+public final class PostCategoryChannelNames {
+    private PostCategoryChannelNames() {}
+
+    /**
+     * Channel for post category updates
+     */
+    public static String postCategories() {
+        return "post.categories";
+    }
+}

--- a/src/main/java/org/phong/horizon/post/utils/PostChannelNames.java
+++ b/src/main/java/org/phong/horizon/post/utils/PostChannelNames.java
@@ -1,0 +1,21 @@
+package org.phong.horizon.post.utils;
+
+import java.util.UUID;
+
+public final class PostChannelNames {
+    private PostChannelNames() {}
+
+    /**
+     * Channel for broadcast post creation events
+     */
+    public static String posts() {
+        return "posts";
+    }
+
+    /**
+     * Channel for events related to a specific post
+     */
+    public static String post(UUID postId) {
+        return "posts." + postId;
+    }
+}

--- a/src/main/java/org/phong/horizon/report/events/ReportCreatedEvent.java
+++ b/src/main/java/org/phong/horizon/report/events/ReportCreatedEvent.java
@@ -1,13 +1,15 @@
 package org.phong.horizon.report.events;
 
 import lombok.Getter;
+import org.phong.horizon.ably.event.AblyPublishableEvent;
 import org.phong.horizon.report.enums.ModerationItemType;
+import org.phong.horizon.report.utils.ReportChannelNames;
 import org.springframework.context.ApplicationEvent;
 
 import java.util.UUID;
 
 @Getter
-public class ReportCreatedEvent extends ApplicationEvent {
+public class ReportCreatedEvent extends ApplicationEvent implements AblyPublishableEvent {
     private final UUID reportId;
     private final UUID reporterId;
     private final UUID reportedItemId; // ID of the post, comment, or user being reported
@@ -23,6 +25,16 @@ public class ReportCreatedEvent extends ApplicationEvent {
         this.itemType = itemType;
         this.actualReportedUserId = actualReportedUserId;
         this.reason = reason;
+    }
+
+    @Override
+    public String getChannelName() {
+        return ReportChannelNames.reports();
+    }
+
+    @Override
+    public String getEventName() {
+        return "report.created";
     }
 }
 

--- a/src/main/java/org/phong/horizon/report/utils/ReportChannelNames.java
+++ b/src/main/java/org/phong/horizon/report/utils/ReportChannelNames.java
@@ -1,0 +1,12 @@
+package org.phong.horizon.report.utils;
+
+public final class ReportChannelNames {
+    private ReportChannelNames() {}
+
+    /**
+     * Global channel for new reports
+     */
+    public static String reports() {
+        return "reports";
+    }
+}

--- a/src/main/java/org/phong/horizon/user/events/UserAccountUpdatedEvent.java
+++ b/src/main/java/org/phong/horizon/user/events/UserAccountUpdatedEvent.java
@@ -3,7 +3,9 @@ package org.phong.horizon.user.events;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.experimental.FieldDefaults;
+import org.phong.horizon.ably.event.AblyPublishableEvent;
 import org.phong.horizon.core.dtos.FieldValueChange;
+import org.phong.horizon.user.utils.UserChannelNames;
 import org.springframework.context.ApplicationEvent;
 
 import java.util.Map;
@@ -11,7 +13,7 @@ import java.util.UUID;
 
 @FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
 @Getter
-public class UserAccountUpdatedEvent extends ApplicationEvent {
+public class UserAccountUpdatedEvent extends ApplicationEvent implements AblyPublishableEvent {
     UUID userId;
     String username;
     String email;
@@ -33,5 +35,15 @@ public class UserAccountUpdatedEvent extends ApplicationEvent {
         this.additionalInfo = additionalInfo;
         this.userAgent = userAgent;
         this.clientIp = clientIp;
+    }
+
+    @Override
+    public String getChannelName() {
+        return UserChannelNames.user(userId);
+    }
+
+    @Override
+    public String getEventName() {
+        return "user.account.updated";
     }
 }

--- a/src/main/java/org/phong/horizon/user/events/UserCreatedEvent.java
+++ b/src/main/java/org/phong/horizon/user/events/UserCreatedEvent.java
@@ -1,12 +1,14 @@
 package org.phong.horizon.user.events;
 
 import lombok.Getter;
+import org.phong.horizon.ably.event.AblyPublishableEvent;
+import org.phong.horizon.user.utils.UserChannelNames;
 import org.springframework.context.ApplicationEvent;
 
 import java.util.UUID;
 
 @Getter
-public class UserCreatedEvent extends ApplicationEvent {
+public class UserCreatedEvent extends ApplicationEvent implements AblyPublishableEvent {
     private final UUID userId;
     private final String username;
     private final String email;
@@ -16,5 +18,15 @@ public class UserCreatedEvent extends ApplicationEvent {
         this.userId = userId;
         this.username = username;
         this.email = email;
+    }
+
+    @Override
+    public String getChannelName() {
+        return UserChannelNames.users();
+    }
+
+    @Override
+    public String getEventName() {
+        return "user.created";
     }
 }

--- a/src/main/java/org/phong/horizon/user/events/UserDeletedEvent.java
+++ b/src/main/java/org/phong/horizon/user/events/UserDeletedEvent.java
@@ -1,12 +1,14 @@
 package org.phong.horizon.user.events;
 
 import lombok.Getter;
+import org.phong.horizon.ably.event.AblyPublishableEvent;
+import org.phong.horizon.user.utils.UserChannelNames;
 import org.springframework.context.ApplicationEvent;
 
 import java.util.UUID;
 
 @Getter
-public class UserDeletedEvent extends ApplicationEvent {
+public class UserDeletedEvent extends ApplicationEvent implements AblyPublishableEvent {
     private final UUID userId;
     private final String username;
     private final String email;
@@ -16,5 +18,15 @@ public class UserDeletedEvent extends ApplicationEvent {
         this.userId = userId;
         this.username = username;
         this.email = email;
+    }
+
+    @Override
+    public String getChannelName() {
+        return UserChannelNames.user(userId);
+    }
+
+    @Override
+    public String getEventName() {
+        return "user.deleted";
     }
 }

--- a/src/main/java/org/phong/horizon/user/events/UserInfoUpdatedEvent.java
+++ b/src/main/java/org/phong/horizon/user/events/UserInfoUpdatedEvent.java
@@ -1,14 +1,16 @@
 package org.phong.horizon.user.events;
 
 import lombok.Getter;
+import org.phong.horizon.ably.event.AblyPublishableEvent;
 import org.phong.horizon.core.dtos.FieldValueChange;
+import org.phong.horizon.user.utils.UserChannelNames;
 import org.springframework.context.ApplicationEvent;
 
 import java.util.Map;
 import java.util.UUID;
 
 @Getter
-public class UserInfoUpdatedEvent extends ApplicationEvent {
+public class UserInfoUpdatedEvent extends ApplicationEvent implements AblyPublishableEvent {
     private final UUID userId;
     private final String username;
     private final String email;
@@ -28,5 +30,15 @@ public class UserInfoUpdatedEvent extends ApplicationEvent {
         this.additionalInfo = additionalInfo;
         this.userAgent = userAgent;
         this.clientIp = clientIp;
+    }
+
+    @Override
+    public String getChannelName() {
+        return UserChannelNames.user(userId);
+    }
+
+    @Override
+    public String getEventName() {
+        return "user.info.updated";
     }
 }

--- a/src/main/java/org/phong/horizon/user/events/UserRestoreEvent.java
+++ b/src/main/java/org/phong/horizon/user/events/UserRestoreEvent.java
@@ -1,16 +1,28 @@
 package org.phong.horizon.user.events;
 
 import lombok.Getter;
+import org.phong.horizon.ably.event.AblyPublishableEvent;
+import org.phong.horizon.user.utils.UserChannelNames;
 import org.springframework.context.ApplicationEvent;
 
 import java.util.UUID;
 
 @Getter
-public class UserRestoreEvent extends ApplicationEvent {
+public class UserRestoreEvent extends ApplicationEvent implements AblyPublishableEvent {
     private final UUID userId;
 
     public UserRestoreEvent(Object source, UUID id) {
         super(source);
         this.userId = id;
+    }
+
+    @Override
+    public String getChannelName() {
+        return UserChannelNames.user(userId);
+    }
+
+    @Override
+    public String getEventName() {
+        return "user.restored";
     }
 }

--- a/src/main/java/org/phong/horizon/user/utils/UserChannelNames.java
+++ b/src/main/java/org/phong/horizon/user/utils/UserChannelNames.java
@@ -1,0 +1,21 @@
+package org.phong.horizon.user.utils;
+
+import java.util.UUID;
+
+public final class UserChannelNames {
+    private UserChannelNames() {}
+
+    /**
+     * Channel for user creation events. Represents all users collectively.
+     */
+    public static String users() {
+        return "users";
+    }
+
+    /**
+     * Channel for events scoped to a specific user.
+     */
+    public static String user(UUID userId) {
+        return "users." + userId;
+    }
+}


### PR DESCRIPTION
## Summary
- implement `AblyPublishableEvent` for post, follow, notification, admin, report and other domain events
- add helper classes to create Ably channel names for each domain
- update `PostCategoryUpdate` to emit Ably events

## Testing
- `sh gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_b_684d448897c88326980c1415edb292a1