### PR TITLE
Implement auto publish for notifications

### DIFF
--- a/src/main/java/org/phong/horizon/comment/events/CommentPinned.java
+++ b/src/main/java/org/phong/horizon/comment/events/CommentPinned.java
@@ -4,13 +4,16 @@ import lombok.Getter;
 import lombok.experimental.FieldDefaults;
 import org.phong.horizon.ably.event.AblyPublishableEvent;
 import org.phong.horizon.comment.utils.CommentChannelNames;
+import org.phong.horizon.notification.dtos.CreateNotificationRequest;
+import org.phong.horizon.notification.enums.NotificationType;
+import org.phong.horizon.notification.events.NotificationPublishableEvent;
 import org.springframework.context.ApplicationEvent;
 
 import java.util.UUID;
 
 @Getter
 @FieldDefaults(makeFinal = true, level = lombok.AccessLevel.PRIVATE)
-public class CommentPinned extends ApplicationEvent implements AblyPublishableEvent {
+public class CommentPinned extends ApplicationEvent implements AblyPublishableEvent, NotificationPublishableEvent {
     UUID commentId;
     UUID postId;
     UUID pinnerId;
@@ -32,5 +35,14 @@ public class CommentPinned extends ApplicationEvent implements AblyPublishableEv
     @Override
     public String getEventName() {
         return "comment.pinned";
+    }
+
+    @Override
+    public CreateNotificationRequest getNotificationRequest() {
+        return CreateNotificationRequest.builder()
+                .recipientUserId(pinnedUserId)
+                .content("Your post has been successfully updated.")
+                .type(NotificationType.SYSTEM_MESSAGE)
+                .build();
     }
 }

--- a/src/main/java/org/phong/horizon/comment/events/CommentUnPinned.java
+++ b/src/main/java/org/phong/horizon/comment/events/CommentUnPinned.java
@@ -4,13 +4,16 @@ import lombok.Getter;
 import lombok.experimental.FieldDefaults;
 import org.phong.horizon.ably.event.AblyPublishableEvent;
 import org.phong.horizon.comment.utils.CommentChannelNames;
+import org.phong.horizon.notification.dtos.CreateNotificationRequest;
+import org.phong.horizon.notification.enums.NotificationType;
+import org.phong.horizon.notification.events.NotificationPublishableEvent;
 import org.springframework.context.ApplicationEvent;
 
 import java.util.UUID;
 
 @Getter
 @FieldDefaults(makeFinal = true, level = lombok.AccessLevel.PRIVATE)
-public class CommentUnPinned extends ApplicationEvent implements AblyPublishableEvent {
+public class CommentUnPinned extends ApplicationEvent implements AblyPublishableEvent, NotificationPublishableEvent {
     UUID commentId;
     UUID postId;
     UUID unpinnerId;
@@ -32,5 +35,14 @@ public class CommentUnPinned extends ApplicationEvent implements AblyPublishable
     @Override
     public String getEventName() {
         return "comment.unpinned";
+    }
+
+    @Override
+    public CreateNotificationRequest getNotificationRequest() {
+        return CreateNotificationRequest.builder()
+                .recipientUserId(unpinnedUserId)
+                .content("Your post has been successfully updated.")
+                .type(NotificationType.SYSTEM_MESSAGE)
+                .build();
     }
 }

--- a/src/main/java/org/phong/horizon/comment/listeners/CommentListener.java
+++ b/src/main/java/org/phong/horizon/comment/listeners/CommentListener.java
@@ -9,9 +9,6 @@ import org.phong.horizon.core.enums.SystemCategory;
 import org.phong.horizon.historyactivity.dtos.CreateHistoryActivity;
 import org.phong.horizon.historyactivity.enums.ActivityTypeCode;
 import org.phong.horizon.historyactivity.events.CreateHistoryLogEvent;
-import org.phong.horizon.notification.dtos.CreateNotificationRequest;
-import org.phong.horizon.notification.enums.NotificationType;
-import org.phong.horizon.notification.events.CreateNotificationEvent;
 import org.phong.horizon.user.events.UserDeletedEvent;
 import org.phong.horizon.user.events.UserRestoreEvent;
 import org.springframework.context.ApplicationEventPublisher;
@@ -63,35 +60,6 @@ public class CommentListener {
         commentService.restoreCommentsByPostId(event.getUserId());
     }
 
-    @EventListener
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    @Async
-    public void onCommentPinned(CommentPinned event) {
-        eventPublisher.publishEvent(new CreateNotificationEvent(
-                this,
-                event.getPinnerId(),
-                CreateNotificationRequest.builder()
-                        .recipientUserId(event.getPinnedUserId())
-                        .content("Your post has been successfully updated.")
-                        .type(NotificationType.SYSTEM_MESSAGE)
-                        .build()
-        ));
-    }
-
-    @EventListener
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    @Async
-    public void onCommentUnPinned(CommentUnPinned event) {
-        eventPublisher.publishEvent(
-                new CreateNotificationEvent(
-                        this,
-                        event.getUnpinnerId(),
-                        CreateNotificationRequest.builder()
-                                .recipientUserId(event.getUnpinnedUserId())
-                                .content("Your post has been successfully updated.")
-                                .type(NotificationType.SYSTEM_MESSAGE)
-                                .build()
-                )
-        );
-    }
+    // Notification events are now handled directly by the CommentPinned and
+    // CommentUnPinned events via the NotificationPublishableEvent interface.
 }

--- a/src/main/java/org/phong/horizon/follow/events/UserFollowedEvent.java
+++ b/src/main/java/org/phong/horizon/follow/events/UserFollowedEvent.java
@@ -3,12 +3,15 @@ package org.phong.horizon.follow.events;
 import lombok.Getter;
 import org.phong.horizon.ably.event.AblyPublishableEvent;
 import org.phong.horizon.follow.utils.FollowChannelNames;
+import org.phong.horizon.notification.dtos.CreateNotificationRequest;
+import org.phong.horizon.notification.enums.NotificationType;
+import org.phong.horizon.notification.events.NotificationPublishableEvent;
 import org.springframework.context.ApplicationEvent;
 
 import java.util.UUID;
 
 @Getter
-public class UserFollowedEvent extends ApplicationEvent implements AblyPublishableEvent {
+public class UserFollowedEvent extends ApplicationEvent implements AblyPublishableEvent, NotificationPublishableEvent {
     private final String followerUsername;
     private final String followedUsername;
     private final UUID followedUserId;
@@ -34,5 +37,14 @@ public class UserFollowedEvent extends ApplicationEvent implements AblyPublishab
     @Override
     public String getEventName() {
         return "user.followed";
+    }
+
+    @Override
+    public CreateNotificationRequest getNotificationRequest() {
+        return CreateNotificationRequest.builder()
+                .recipientUserId(followedUserId)
+                .content("You have a new follower: " + followerUsername)
+                .type(NotificationType.NEW_FOLLOWER)
+                .build();
     }
 }

--- a/src/main/java/org/phong/horizon/follow/listeners/FollowListener.java
+++ b/src/main/java/org/phong/horizon/follow/listeners/FollowListener.java
@@ -3,9 +3,6 @@ package org.phong.horizon.follow.listeners;
 import lombok.AllArgsConstructor;
 import org.phong.horizon.follow.events.UserFollowedEvent;
 import org.phong.horizon.follow.services.FollowService;
-import org.phong.horizon.notification.dtos.CreateNotificationRequest;
-import org.phong.horizon.notification.enums.NotificationType;
-import org.phong.horizon.notification.events.CreateNotificationEvent;
 import org.phong.horizon.user.events.UserDeletedEvent;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.event.EventListener;
@@ -21,15 +18,7 @@ public class FollowListener {
 
     @EventListener
     public void onFollowCreated(UserFollowedEvent event) {
-        eventPublisher.publishEvent(new CreateNotificationEvent(
-                this,
-                event.getFollowerUserId(),
-                CreateNotificationRequest.builder()
-                        .recipientUserId(event.getFollowedUserId())
-                        .content("You have a new follower: " + event.getFollowerUsername())
-                        .type(NotificationType.NEW_FOLLOWER)
-                        .build()
-        ));
+        // Notification for this event is handled by UserFollowedEvent itself.
     }
 
     @EventListener

--- a/src/main/java/org/phong/horizon/post/events/PostCreatedEvent.java
+++ b/src/main/java/org/phong/horizon/post/events/PostCreatedEvent.java
@@ -3,12 +3,15 @@ package org.phong.horizon.post.events;
 import lombok.Getter;
 import org.phong.horizon.ably.event.AblyPublishableEvent;
 import org.phong.horizon.post.utils.PostChannelNames;
+import org.phong.horizon.notification.dtos.CreateNotificationRequest;
+import org.phong.horizon.notification.enums.NotificationType;
+import org.phong.horizon.notification.events.NotificationPublishableEvent;
 import org.springframework.context.ApplicationEvent;
 
 import java.util.UUID;
 
 @Getter
-public class PostCreatedEvent extends ApplicationEvent implements AblyPublishableEvent {
+public class PostCreatedEvent extends ApplicationEvent implements AblyPublishableEvent, NotificationPublishableEvent {
     private final UUID postId;
     private final UUID userId;
     private final String title;
@@ -30,5 +33,14 @@ public class PostCreatedEvent extends ApplicationEvent implements AblyPublishabl
     @Override
     public String getEventName() {
         return "post.created";
+    }
+
+    @Override
+    public CreateNotificationRequest getNotificationRequest() {
+        return CreateNotificationRequest.builder()
+                .recipientUserId(userId)
+                .content("Your post has been successfully created.")
+                .type(NotificationType.SYSTEM_MESSAGE)
+                .build();
     }
 }

--- a/src/main/java/org/phong/horizon/post/events/PostDeletedEvent.java
+++ b/src/main/java/org/phong/horizon/post/events/PostDeletedEvent.java
@@ -3,12 +3,15 @@ package org.phong.horizon.post.events;
 import lombok.Getter;
 import org.phong.horizon.ably.event.AblyPublishableEvent;
 import org.phong.horizon.post.utils.PostChannelNames;
+import org.phong.horizon.notification.dtos.CreateNotificationRequest;
+import org.phong.horizon.notification.enums.NotificationType;
+import org.phong.horizon.notification.events.NotificationPublishableEvent;
 import org.springframework.context.ApplicationEvent;
 
 import java.util.UUID;
 
 @Getter
-public class PostDeletedEvent extends ApplicationEvent implements AblyPublishableEvent {
+public class PostDeletedEvent extends ApplicationEvent implements AblyPublishableEvent, NotificationPublishableEvent {
     private final UUID postId;
     private final UUID userId;
 
@@ -26,5 +29,14 @@ public class PostDeletedEvent extends ApplicationEvent implements AblyPublishabl
     @Override
     public String getEventName() {
         return "post.deleted";
+    }
+
+    @Override
+    public CreateNotificationRequest getNotificationRequest() {
+        return CreateNotificationRequest.builder()
+                .recipientUserId(userId)
+                .content("Your post has been successfully deleted.")
+                .type(NotificationType.SYSTEM_MESSAGE)
+                .build();
     }
 }

--- a/src/main/java/org/phong/horizon/post/events/PostUpdatedEvent.java
+++ b/src/main/java/org/phong/horizon/post/events/PostUpdatedEvent.java
@@ -4,13 +4,16 @@ import lombok.Getter;
 import org.phong.horizon.ably.event.AblyPublishableEvent;
 import org.phong.horizon.core.dtos.FieldValueChange;
 import org.phong.horizon.post.utils.PostChannelNames;
+import org.phong.horizon.notification.dtos.CreateNotificationRequest;
+import org.phong.horizon.notification.enums.NotificationType;
+import org.phong.horizon.notification.events.NotificationPublishableEvent;
 import org.springframework.context.ApplicationEvent;
 
 import java.util.Map;
 import java.util.UUID;
 
 @Getter
-public class PostUpdatedEvent extends ApplicationEvent implements AblyPublishableEvent {
+public class PostUpdatedEvent extends ApplicationEvent implements AblyPublishableEvent, NotificationPublishableEvent {
     private final UUID postId;
     private final UUID userId;
     private final String caption;
@@ -43,5 +46,14 @@ public class PostUpdatedEvent extends ApplicationEvent implements AblyPublishabl
     @Override
     public String getEventName() {
         return "post.updated";
+    }
+
+    @Override
+    public CreateNotificationRequest getNotificationRequest() {
+        return CreateNotificationRequest.builder()
+                .recipientUserId(userId)
+                .content("Your post has been successfully updated.")
+                .type(NotificationType.SYSTEM_MESSAGE)
+                .build();
     }
 }

--- a/src/main/java/org/phong/horizon/post/listeners/PostListener.java
+++ b/src/main/java/org/phong/horizon/post/listeners/PostListener.java
@@ -5,9 +5,6 @@ import org.phong.horizon.core.enums.SystemCategory;
 import org.phong.horizon.historyactivity.dtos.CreateHistoryActivity;
 import org.phong.horizon.historyactivity.enums.ActivityTypeCode;
 import org.phong.horizon.historyactivity.events.CreateHistoryLogEvent;
-import org.phong.horizon.notification.dtos.CreateNotificationRequest;
-import org.phong.horizon.notification.enums.NotificationType;
-import org.phong.horizon.notification.events.CreateNotificationEvent;
 import org.phong.horizon.post.events.PostCreatedEvent;
 import org.phong.horizon.post.events.PostDeletedEvent;
 import org.phong.horizon.post.events.PostUpdatedEvent;
@@ -31,31 +28,7 @@ public class PostListener {
     @Async
     @TransactionalEventListener
     @EventListener
-    public void onPostCreated(PostCreatedEvent event) {
-        eventPublisher.publishEvent(new CreateNotificationEvent(
-                this,
-                event.getUserId(),
-                CreateNotificationRequest.builder()
-                        .recipientUserId(event.getUserId())
-                        .content("Your post has been successfully created.")
-                        .type(NotificationType.SYSTEM_MESSAGE)
-                        .build()
-        ));
-    }
-
-    @Async
-    @TransactionalEventListener
-    @EventListener
     public void onPostUpdated(PostUpdatedEvent event) {
-        eventPublisher.publishEvent(new CreateNotificationEvent(
-                this,
-                event.getUserId(),
-                CreateNotificationRequest.builder()
-                        .recipientUserId(event.getUserId())
-                        .content("Your post has been successfully updated.")
-                        .type(NotificationType.SYSTEM_MESSAGE)
-                        .build()
-        ));
 
         eventPublisher.publishEvent(new CreateHistoryLogEvent(
                 this,
@@ -76,15 +49,8 @@ public class PostListener {
     @TransactionalEventListener
     @EventListener
     public void onPostDeleted(PostDeletedEvent event) {
-        eventPublisher.publishEvent(new CreateNotificationEvent(
-                this,
-                event.getUserId(),
-                CreateNotificationRequest.builder()
-                        .recipientUserId(event.getUserId())
-                        .content("Your post has been successfully deleted.")
-                        .type(NotificationType.SYSTEM_MESSAGE)
-                        .build()
-        ));
+        // Notification for this event is handled directly by PostDeletedEvent
+        // via the NotificationPublishableEvent interface.
     }
 
     @EventListener

--- a/src/main/java/org/phong/horizon/user/events/UserAccountUpdatedEvent.java
+++ b/src/main/java/org/phong/horizon/user/events/UserAccountUpdatedEvent.java
@@ -6,6 +6,9 @@ import lombok.experimental.FieldDefaults;
 import org.phong.horizon.ably.event.AblyPublishableEvent;
 import org.phong.horizon.core.dtos.FieldValueChange;
 import org.phong.horizon.user.utils.UserChannelNames;
+import org.phong.horizon.notification.dtos.CreateNotificationRequest;
+import org.phong.horizon.notification.enums.NotificationType;
+import org.phong.horizon.notification.events.NotificationPublishableEvent;
 import org.springframework.context.ApplicationEvent;
 
 import java.util.Map;
@@ -13,7 +16,7 @@ import java.util.UUID;
 
 @FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
 @Getter
-public class UserAccountUpdatedEvent extends ApplicationEvent implements AblyPublishableEvent {
+public class UserAccountUpdatedEvent extends ApplicationEvent implements AblyPublishableEvent, NotificationPublishableEvent {
     UUID userId;
     String username;
     String email;
@@ -45,5 +48,15 @@ public class UserAccountUpdatedEvent extends ApplicationEvent implements AblyPub
     @Override
     public String getEventName() {
         return "user.account.updated";
+    }
+
+    @Override
+    public CreateNotificationRequest getNotificationRequest() {
+        return CreateNotificationRequest.builder()
+                .recipientUserId(userId)
+                .content("Your account information has been successfully updated.")
+                .extraData(Map.of("diffChange", additionalInfo))
+                .type(NotificationType.SYSTEM_MESSAGE)
+                .build();
     }
 }

--- a/src/main/java/org/phong/horizon/user/events/UserCreatedEvent.java
+++ b/src/main/java/org/phong/horizon/user/events/UserCreatedEvent.java
@@ -3,12 +3,15 @@ package org.phong.horizon.user.events;
 import lombok.Getter;
 import org.phong.horizon.ably.event.AblyPublishableEvent;
 import org.phong.horizon.user.utils.UserChannelNames;
+import org.phong.horizon.notification.dtos.CreateNotificationRequest;
+import org.phong.horizon.notification.enums.NotificationType;
+import org.phong.horizon.notification.events.NotificationPublishableEvent;
 import org.springframework.context.ApplicationEvent;
 
 import java.util.UUID;
 
 @Getter
-public class UserCreatedEvent extends ApplicationEvent implements AblyPublishableEvent {
+public class UserCreatedEvent extends ApplicationEvent implements AblyPublishableEvent, NotificationPublishableEvent {
     private final UUID userId;
     private final String username;
     private final String email;
@@ -28,5 +31,14 @@ public class UserCreatedEvent extends ApplicationEvent implements AblyPublishabl
     @Override
     public String getEventName() {
         return "user.created";
+    }
+
+    @Override
+    public CreateNotificationRequest getNotificationRequest() {
+        return CreateNotificationRequest.builder()
+                .recipientUserId(userId)
+                .content("Welcome to Horizon! Your account has been successfully created.")
+                .type(NotificationType.SYSTEM_MESSAGE)
+                .build();
     }
 }

--- a/src/main/java/org/phong/horizon/user/events/UserDeletedEvent.java
+++ b/src/main/java/org/phong/horizon/user/events/UserDeletedEvent.java
@@ -3,12 +3,15 @@ package org.phong.horizon.user.events;
 import lombok.Getter;
 import org.phong.horizon.ably.event.AblyPublishableEvent;
 import org.phong.horizon.user.utils.UserChannelNames;
+import org.phong.horizon.notification.dtos.CreateNotificationRequest;
+import org.phong.horizon.notification.enums.NotificationType;
+import org.phong.horizon.notification.events.NotificationPublishableEvent;
 import org.springframework.context.ApplicationEvent;
 
 import java.util.UUID;
 
 @Getter
-public class UserDeletedEvent extends ApplicationEvent implements AblyPublishableEvent {
+public class UserDeletedEvent extends ApplicationEvent implements AblyPublishableEvent, NotificationPublishableEvent {
     private final UUID userId;
     private final String username;
     private final String email;
@@ -28,5 +31,14 @@ public class UserDeletedEvent extends ApplicationEvent implements AblyPublishabl
     @Override
     public String getEventName() {
         return "user.deleted";
+    }
+
+    @Override
+    public CreateNotificationRequest getNotificationRequest() {
+        return CreateNotificationRequest.builder()
+                .recipientUserId(userId)
+                .content("Your account has been successfully deleted.")
+                .type(NotificationType.SYSTEM_MESSAGE)
+                .build();
     }
 }

--- a/src/main/java/org/phong/horizon/user/events/UserInfoUpdatedEvent.java
+++ b/src/main/java/org/phong/horizon/user/events/UserInfoUpdatedEvent.java
@@ -4,13 +4,16 @@ import lombok.Getter;
 import org.phong.horizon.ably.event.AblyPublishableEvent;
 import org.phong.horizon.core.dtos.FieldValueChange;
 import org.phong.horizon.user.utils.UserChannelNames;
+import org.phong.horizon.notification.dtos.CreateNotificationRequest;
+import org.phong.horizon.notification.enums.NotificationType;
+import org.phong.horizon.notification.events.NotificationPublishableEvent;
 import org.springframework.context.ApplicationEvent;
 
 import java.util.Map;
 import java.util.UUID;
 
 @Getter
-public class UserInfoUpdatedEvent extends ApplicationEvent implements AblyPublishableEvent {
+public class UserInfoUpdatedEvent extends ApplicationEvent implements AblyPublishableEvent, NotificationPublishableEvent {
     private final UUID userId;
     private final String username;
     private final String email;
@@ -40,5 +43,15 @@ public class UserInfoUpdatedEvent extends ApplicationEvent implements AblyPublis
     @Override
     public String getEventName() {
         return "user.info.updated";
+    }
+
+    @Override
+    public CreateNotificationRequest getNotificationRequest() {
+        return CreateNotificationRequest.builder()
+                .recipientUserId(userId)
+                .content("Your personal information has been successfully updated.")
+                .extraData(Map.of("diffChange", additionalInfo))
+                .type(NotificationType.SYSTEM_MESSAGE)
+                .build();
     }
 }

--- a/src/main/java/org/phong/horizon/user/events/UserRestoreEvent.java
+++ b/src/main/java/org/phong/horizon/user/events/UserRestoreEvent.java
@@ -3,12 +3,15 @@ package org.phong.horizon.user.events;
 import lombok.Getter;
 import org.phong.horizon.ably.event.AblyPublishableEvent;
 import org.phong.horizon.user.utils.UserChannelNames;
+import org.phong.horizon.notification.dtos.CreateNotificationRequest;
+import org.phong.horizon.notification.enums.NotificationType;
+import org.phong.horizon.notification.events.NotificationPublishableEvent;
 import org.springframework.context.ApplicationEvent;
 
 import java.util.UUID;
 
 @Getter
-public class UserRestoreEvent extends ApplicationEvent implements AblyPublishableEvent {
+public class UserRestoreEvent extends ApplicationEvent implements AblyPublishableEvent, NotificationPublishableEvent {
     private final UUID userId;
 
     public UserRestoreEvent(Object source, UUID id) {
@@ -24,5 +27,14 @@ public class UserRestoreEvent extends ApplicationEvent implements AblyPublishabl
     @Override
     public String getEventName() {
         return "user.restored";
+    }
+
+    @Override
+    public CreateNotificationRequest getNotificationRequest() {
+        return CreateNotificationRequest.builder()
+                .recipientUserId(userId)
+                .content("Your account has been successfully restore.")
+                .type(NotificationType.SYSTEM_MESSAGE)
+                .build();
     }
 }

--- a/src/main/java/org/phong/horizon/user/listeners/UserListener.java
+++ b/src/main/java/org/phong/horizon/user/listeners/UserListener.java
@@ -5,12 +5,7 @@ import org.phong.horizon.core.enums.SystemCategory;
 import org.phong.horizon.historyactivity.dtos.CreateHistoryActivity;
 import org.phong.horizon.historyactivity.enums.ActivityTypeCode;
 import org.phong.horizon.historyactivity.events.CreateHistoryLogEvent;
-import org.phong.horizon.notification.dtos.CreateNotificationRequest;
-import org.phong.horizon.notification.enums.NotificationType;
-import org.phong.horizon.notification.events.CreateNotificationEvent;
 import org.phong.horizon.user.events.UserAccountUpdatedEvent;
-import org.phong.horizon.user.events.UserCreatedEvent;
-import org.phong.horizon.user.events.UserDeletedEvent;
 import org.phong.horizon.user.events.UserRestoreEvent;
 import org.phong.horizon.user.events.UserInfoUpdatedEvent;
 import org.springframework.context.ApplicationEventPublisher;
@@ -27,47 +22,11 @@ import java.util.Map;
 public class UserListener {
     private final ApplicationEventPublisher eventPublisher;
 
-    @EventListener
-    public void onUserCreated(UserCreatedEvent event) {
-        eventPublisher.publishEvent(new CreateNotificationEvent(
-                this,
-                event.getUserId(),
-                CreateNotificationRequest.builder()
-                        .recipientUserId(event.getUserId())
-                        .content("Welcome to Horizon! Your account has been successfully created.")
-                        .type(NotificationType.SYSTEM_MESSAGE)
-                        .build()
-        ));
-    }
-
-    //why do I send event to notification the user has deleted the account? This is nonsense but just keep it
-    @EventListener
-    @TransactionalEventListener
-    @Async
-    public void onUserDeleted(UserDeletedEvent event) {
-        eventPublisher.publishEvent(new CreateNotificationEvent(
-                this,
-                event.getUserId(),
-                CreateNotificationRequest.builder()
-                        .recipientUserId(event.getUserId())
-                        .content("Your account has been successfully deleted.")
-                        .type(NotificationType.SYSTEM_MESSAGE)
-                        .build()
-        ));
-    }
+    // Notification events are handled by the domain events themselves via
+    // the NotificationPublishableEvent interface.
 
     @EventListener
     public void onUserInfoUpdated(UserInfoUpdatedEvent event) {
-        eventPublisher.publishEvent(new CreateNotificationEvent(
-                this,
-                event.getUserId(),
-                CreateNotificationRequest.builder()
-                        .recipientUserId(event.getUserId())
-                        .content("Your personal information has been successfully updated.")
-                        .extraData(Map.of("diffChange", event.getAdditionalInfo()))
-                        .type(NotificationType.SYSTEM_MESSAGE)
-                        .build()
-        ));
 
         eventPublisher.publishEvent(new CreateHistoryLogEvent(
                 this,
@@ -86,16 +45,6 @@ public class UserListener {
 
     @EventListener
     public void onUserAccountUpdated(UserAccountUpdatedEvent event) {
-        eventPublisher.publishEvent(new CreateNotificationEvent(
-                this,
-                event.getUserId(),
-                CreateNotificationRequest.builder()
-                        .recipientUserId(event.getUserId())
-                        .content("Your account information has been successfully updated.")
-                        .type(NotificationType.SYSTEM_MESSAGE)
-                        .extraData(Map.of("diffChange", event.getAdditionalInfo()))
-                        .build()
-        ));
 
         eventPublisher.publishEvent(new CreateHistoryLogEvent(
                 this,
@@ -116,14 +65,6 @@ public class UserListener {
     @Async
     @TransactionalEventListener
     public void onUserRestoreEvent(UserRestoreEvent event) {
-        eventPublisher.publishEvent(new CreateNotificationEvent(
-                this,
-                event.getUserId(),
-                CreateNotificationRequest.builder()
-                        .recipientUserId(event.getUserId())
-                        .content("Your account has been successfully restore.")
-                        .type(NotificationType.SYSTEM_MESSAGE)
-                        .build()
-        ));
+        // Notification for this event is handled by UserRestoreEvent itself.
     }
 }


### PR DESCRIPTION
## Summary
- introduce NotificationPublishableEvent to several domain events
- stop publishing CreateNotificationEvent in domain listeners
- handle new notification logic directly in events

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_b_684da20382b08326a6946b1695f57954