### PR TITLE
Add localization support with English/Vietnamese messages

### DIFF
--- a/src/main/java/org/phong/horizon/admin/notification/enums/AdminNotificationErrorMessage.java
+++ b/src/main/java/org/phong/horizon/admin/notification/enums/AdminNotificationErrorMessage.java
@@ -6,9 +6,13 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum AdminNotificationErrorMessage {
-    NOTIFICATION_NOT_FOUND("Notification not found with id: %s"),
-    INVALID_NOTIFICATION_DATA("Invalid notification data provided.");
+    NOTIFICATION_NOT_FOUND("admin.notification.error.not_found"),
+    INVALID_NOTIFICATION_DATA("admin.notification.error.invalid_data");
 
-    private final String message;
+    private final String messageKey;
+
+    public String getMessage(Object... args) {
+        return org.phong.horizon.core.config.LocalizationProvider.getMessage(this.messageKey, args);
+    }
 }
 

--- a/src/main/java/org/phong/horizon/comment/enums/CommentErrorEnums.java
+++ b/src/main/java/org/phong/horizon/comment/enums/CommentErrorEnums.java
@@ -4,24 +4,28 @@ import lombok.Getter;
 
 @Getter
 public enum CommentErrorEnums {
-    COMMENT_NOT_FOUND("Comment not found"),
-    USER_NOT_AUTHORIZED("User is not authorized to perform this action"),
-    COMMENT_TOO_LONG("Comment exceeds the maximum allowed length"),
-    INVALID_COMMENT_FORMAT("Comment format is invalid"),
-    COMMENT_ALREADY_DELETED("This comment has already been deleted"),
-    UNAUTHORIZED_ACCESS("Access to the comment is denied"),
-    MISSING_COMMENT_CONTENT("Comment content cannot be empty"),
-    INVALID_USER("The user does not exist"),
-    COMMENT_ALREADY_PINNED("Comment is already pinned"),
-    COMMENT_ALREADY_UNPINNED("Comment is already unpinned"),
-    COMMENT_PINNED("Comment pinned successfully"),
-    COMMENT_UNPINNED("Comment unpinned successfully"),
-    COMMENT_DELETED("Comment deleted successfully"),
-    COMMENT_REPORTED("Comment reported successfully");
-    private final String message;
+    COMMENT_NOT_FOUND("comment.error.not_found"),
+    USER_NOT_AUTHORIZED("comment.error.user_not_authorized"),
+    COMMENT_TOO_LONG("comment.error.comment_too_long"),
+    INVALID_COMMENT_FORMAT("comment.error.invalid_format"),
+    COMMENT_ALREADY_DELETED("comment.error.already_deleted"),
+    UNAUTHORIZED_ACCESS("comment.error.unauthorized_access"),
+    MISSING_COMMENT_CONTENT("comment.error.missing_content"),
+    INVALID_USER("comment.error.invalid_user"),
+    COMMENT_ALREADY_PINNED("comment.error.already_pinned"),
+    COMMENT_ALREADY_UNPINNED("comment.error.already_unpinned"),
+    COMMENT_PINNED("comment.success.pinned"),
+    COMMENT_UNPINNED("comment.success.unpinned"),
+    COMMENT_DELETED("comment.success.deleted"),
+    COMMENT_REPORTED("comment.success.reported");
+    private final String messageKey;
 
-    CommentErrorEnums(String message) {
-        this.message = message;
+    CommentErrorEnums(String messageKey) {
+        this.messageKey = messageKey;
+    }
+
+    public String getMessage(Object... args) {
+        return org.phong.horizon.core.config.LocalizationProvider.getMessage(this.messageKey, args);
     }
 }
 

--- a/src/main/java/org/phong/horizon/comment/enums/CommentInteractionError.java
+++ b/src/main/java/org/phong/horizon/comment/enums/CommentInteractionError.java
@@ -4,17 +4,21 @@ import lombok.Getter;
 
 @Getter
 public enum CommentInteractionError {
-    COMMENT_INTERACTION_EXISTS("Comment interaction already exists"),
-    COMMENT_INTERACTION_NOT_FOUND("Comment interaction not found"),
-    COMMENT_INTERACTION_INVALID("Invalid comment interaction"),
-    COMMENT_INTERACTION_NOT_AUTHORIZED("User is not authorized to perform this action"),
-    COMMENT_INTERACTION_TOO_LONG("Comment interaction exceeds the maximum allowed length"),
-    COMMENT_INTERACTION_ALREADY_DELETED("This comment interaction has already been deleted"),
-    COMMENT_INTERACTION_UNAUTHORIZED_ACCESS("Access to the comment interaction is denied");
+    COMMENT_INTERACTION_EXISTS("comment_interaction.error.exists"),
+    COMMENT_INTERACTION_NOT_FOUND("comment_interaction.error.not_found"),
+    COMMENT_INTERACTION_INVALID("comment_interaction.error.invalid"),
+    COMMENT_INTERACTION_NOT_AUTHORIZED("comment_interaction.error.not_authorized"),
+    COMMENT_INTERACTION_TOO_LONG("comment_interaction.error.too_long"),
+    COMMENT_INTERACTION_ALREADY_DELETED("comment_interaction.error.already_deleted"),
+    COMMENT_INTERACTION_UNAUTHORIZED_ACCESS("comment_interaction.error.unauthorized_access");
 
-    private final String message;
+    private final String messageKey;
 
-    CommentInteractionError(String message) {
-        this.message = message;
+    CommentInteractionError(String messageKey) {
+        this.messageKey = messageKey;
+    }
+
+    public String getMessage(Object... args) {
+        return org.phong.horizon.core.config.LocalizationProvider.getMessage(this.messageKey, args);
     }
 }

--- a/src/main/java/org/phong/horizon/core/config/LocalizationConfig.java
+++ b/src/main/java/org/phong/horizon/core/config/LocalizationConfig.java
@@ -1,0 +1,30 @@
+package org.phong.horizon.core.config;
+
+import org.springframework.context.MessageSource;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.support.ReloadableResourceBundleMessageSource;
+import org.springframework.web.servlet.LocaleResolver;
+import org.springframework.web.servlet.i18n.AcceptHeaderLocaleResolver;
+
+import java.util.Locale;
+
+@Configuration
+public class LocalizationConfig {
+
+    @Bean
+    public MessageSource messageSource() {
+        ReloadableResourceBundleMessageSource messageSource = new ReloadableResourceBundleMessageSource();
+        messageSource.setBasename("classpath:messages");
+        messageSource.setDefaultEncoding("UTF-8");
+        messageSource.setFallbackToSystemLocale(false);
+        return messageSource;
+    }
+
+    @Bean
+    public LocaleResolver localeResolver() {
+        AcceptHeaderLocaleResolver resolver = new AcceptHeaderLocaleResolver();
+        resolver.setDefaultLocale(Locale.ENGLISH);
+        return resolver;
+    }
+}

--- a/src/main/java/org/phong/horizon/core/config/LocalizationProvider.java
+++ b/src/main/java/org/phong/horizon/core/config/LocalizationProvider.java
@@ -1,0 +1,24 @@
+package org.phong.horizon.core.config;
+
+import org.springframework.context.MessageSource;
+import org.springframework.context.MessageSourceAware;
+import org.springframework.context.i18n.LocaleContextHolder;
+import org.springframework.context.support.MessageSourceAccessor;
+import org.springframework.stereotype.Component;
+
+@Component
+public class LocalizationProvider implements MessageSourceAware {
+    private static MessageSourceAccessor accessor;
+
+    @Override
+    public void setMessageSource(MessageSource messageSource) {
+        accessor = new MessageSourceAccessor(messageSource);
+    }
+
+    public static String getMessage(String key, Object... args) {
+        if (accessor == null) {
+            return key;
+        }
+        return accessor.getMessage(key, args, LocaleContextHolder.getLocale());
+    }
+}

--- a/src/main/java/org/phong/horizon/core/enums/SystemError.java
+++ b/src/main/java/org/phong/horizon/core/enums/SystemError.java
@@ -5,21 +5,25 @@ import lombok.Getter;
 
 @Getter
 public enum SystemError {
-    VALIDATION_FAILED_MSG("Validation failed"),
-    MALFORMED_REQUEST_MSG("Malformed JSON request"),
-    METHOD_NOT_SUPPORTED_MSG("Method not supported"),
-    GENERIC_ERROR_MSG("An unexpected error occurred"),
-    MISSING_PARAMETER_MSG("Required parameter is missing"),
-    DATA_INTEGRITY_VIOLATION("Operation cannot be completed due to a data conflict (e.g., duplicate entry or invalid reference)."),
-    INVALID_ARGUMENT_TYPE_MSG("Invalid argument type"),
-    AUTHENTICATION_FAILED("Authentication failed"),
-    ACCESS_DENIED("Access denied"),
-    NOT_FOUND_ENDPOINT("Endpoint not found"),
+    VALIDATION_FAILED_MSG("system.validation_failed"),
+    MALFORMED_REQUEST_MSG("system.malformed_request"),
+    METHOD_NOT_SUPPORTED_MSG("system.method_not_supported"),
+    GENERIC_ERROR_MSG("system.generic_error"),
+    MISSING_PARAMETER_MSG("system.missing_parameter"),
+    DATA_INTEGRITY_VIOLATION("system.data_integrity_violation"),
+    INVALID_ARGUMENT_TYPE_MSG("system.invalid_argument_type"),
+    AUTHENTICATION_FAILED("system.authentication_failed"),
+    ACCESS_DENIED("system.access_denied"),
+    NOT_FOUND_ENDPOINT("system.not_found_endpoint"),
     ;
 
-    private final String errorMessage;
+    private final String messageKey;
 
-    SystemError(String errorMessage) {
-        this.errorMessage = errorMessage;
+    SystemError(String messageKey) {
+        this.messageKey = messageKey;
+    }
+
+    public String getErrorMessage(Object... args) {
+        return org.phong.horizon.core.config.LocalizationProvider.getMessage(this.messageKey, args);
     }
 }

--- a/src/main/java/org/phong/horizon/follow/enums/FollowErrorEnums.java
+++ b/src/main/java/org/phong/horizon/follow/enums/FollowErrorEnums.java
@@ -4,19 +4,23 @@ import lombok.Getter;
 
 @Getter
 public enum FollowErrorEnums {
-    FOLLOW_NOT_FOUND("Follow not found"),
-    FOLLOW_ALREADY_EXISTS("Follow already exists"),
-    FOLLOWER_NOT_FOUND("Follower not found"),
-    FOLLOWING_NOT_FOUND("Following not found"),
-    INVALID_FOLLOW_REQUEST("Invalid follow request"),
-    UNABLE_TO_FOLLOW_SELF("Unable to follow yourself"),
-    UNABLE_TO_UNFOLLOW_SELF("Unable to unfollow yourself"),
-    NOT_FOLLOWING("Not following"),;
+    FOLLOW_NOT_FOUND("follow.error.not_found"),
+    FOLLOW_ALREADY_EXISTS("follow.error.already_exists"),
+    FOLLOWER_NOT_FOUND("follow.error.follower_not_found"),
+    FOLLOWING_NOT_FOUND("follow.error.following_not_found"),
+    INVALID_FOLLOW_REQUEST("follow.error.invalid_request"),
+    UNABLE_TO_FOLLOW_SELF("follow.error.unable_follow_self"),
+    UNABLE_TO_UNFOLLOW_SELF("follow.error.unable_unfollow_self"),
+    NOT_FOLLOWING("follow.error.not_following"),;
 
-    private final String message;
+    private final String messageKey;
 
-    FollowErrorEnums(String message) {
-        this.message = message;
+    FollowErrorEnums(String messageKey) {
+        this.messageKey = messageKey;
+    }
+
+    public String getMessage(Object... args) {
+        return org.phong.horizon.core.config.LocalizationProvider.getMessage(this.messageKey, args);
     }
 
 }

--- a/src/main/java/org/phong/horizon/historyactivity/enums/HistoryActivityBusinessError.java
+++ b/src/main/java/org/phong/horizon/historyactivity/enums/HistoryActivityBusinessError.java
@@ -4,15 +4,19 @@ import lombok.Getter;
 
 @Getter
 public enum HistoryActivityBusinessError {
-    ACTIVITY_TYPE_NOT_FOUND("Activity type not found"),
-    ACTIVITY_TYPE_CODE_NOT_FOUND("Activity type code not found"),
-    ACTIVITY_TYPE_CODE_INVALID("Activity type code is invalid"),
-    ACTIVITY_TYPE_CODE_DUPLICATE("Activity type code is duplicate"),
-    ACTIVITY_TYPE_NAME_DUPLICATE("Activity type name is duplicate");
+    ACTIVITY_TYPE_NOT_FOUND("history_activity.error.type_not_found"),
+    ACTIVITY_TYPE_CODE_NOT_FOUND("history_activity.error.code_not_found"),
+    ACTIVITY_TYPE_CODE_INVALID("history_activity.error.code_invalid"),
+    ACTIVITY_TYPE_CODE_DUPLICATE("history_activity.error.code_duplicate"),
+    ACTIVITY_TYPE_NAME_DUPLICATE("history_activity.error.name_duplicate");
 
-    private final String message;
+    private final String messageKey;
 
-    HistoryActivityBusinessError( String message) {
-        this.message = message;
+    HistoryActivityBusinessError(String messageKey) {
+        this.messageKey = messageKey;
+    }
+
+    public String getMessage(Object... args) {
+        return org.phong.horizon.core.config.LocalizationProvider.getMessage(this.messageKey, args);
     }
 }

--- a/src/main/java/org/phong/horizon/notification/enums/NotificationErrorEnum.java
+++ b/src/main/java/org/phong/horizon/notification/enums/NotificationErrorEnum.java
@@ -4,16 +4,20 @@ import lombok.Getter;
 
 @Getter
 public enum NotificationErrorEnum {
-    NOTIFICATION_NOT_FOUND("Notification not found"),
-    NOTIFICATION_ACCESS_DENIED("You do not have permission to access this notification"),
-    NOTIFICATION_ALREADY_READ("Notification already read"),
-    NOTIFICATION_ALREADY_DELETED("Notification already deleted"),
-    NOTIFICATION_TYPE_NOT_SUPPORTED("Notification type not supported");
+    NOTIFICATION_NOT_FOUND("notification.error.not_found"),
+    NOTIFICATION_ACCESS_DENIED("notification.error.access_denied"),
+    NOTIFICATION_ALREADY_READ("notification.error.already_read"),
+    NOTIFICATION_ALREADY_DELETED("notification.error.already_deleted"),
+    NOTIFICATION_TYPE_NOT_SUPPORTED("notification.error.type_not_supported");
 
-    private final String message;
+    private final String messageKey;
 
-    NotificationErrorEnum(String message) {
-        this.message = message;
+    NotificationErrorEnum(String messageKey) {
+        this.messageKey = messageKey;
+    }
+
+    public String getMessage(Object... args) {
+        return org.phong.horizon.core.config.LocalizationProvider.getMessage(this.messageKey, args);
     }
 
 }

--- a/src/main/java/org/phong/horizon/notification/services/NotificationService.java
+++ b/src/main/java/org/phong/horizon/notification/services/NotificationService.java
@@ -28,6 +28,7 @@ import org.phong.horizon.user.dtos.UserSummaryRespond;
 import org.phong.horizon.user.infrastructure.mapstruct.UserMapper;
 import org.phong.horizon.user.infrastructure.persistence.entities.User;
 import org.phong.horizon.user.services.UserService;
+import org.phong.horizon.core.config.LocalizationProvider;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -168,20 +169,19 @@ public class NotificationService {
 
     private String generateNotificationContent(Notification notification) {
         UserSummaryRespond sender = userMapper.toDto3(notification.getSenderUser());
-        PostSummaryResponse post = postMapper.toDto(notification.getPost());
         NotificationType type = notification.getType();
 
         return switch (type) {
-            case LIKE_POST -> "@" + sender.username() + " liked your post.";
-            case COMMENT_POST -> "@" + sender.username() + " commented on your post.";
-            case LIKE_COMMENT -> "@" + sender.username() + " liked your comment.";
-            case REPLY_COMMENT -> "@" + sender.username() + " replied to your comment.";
-            case MENTION_COMMENT -> "@" + sender.username() + " mentioned you in a comment.";
-            case NEW_FOLLOWER -> "@" + sender.username() + " followed you.";
-            case UN_FOLLOWER -> "@" + sender.username() + " unfollowed you.";
-            case REPORT_COMMENT -> "Your comment was reported.";
-            case REPORT_POST -> "Your post was reported.";
-            case COMMENT_PINNED -> "Your comment was pinned.";
+            case LIKE_POST -> LocalizationProvider.getMessage("notification.content.like_post", "@" + sender.username());
+            case COMMENT_POST -> LocalizationProvider.getMessage("notification.content.comment_post", "@" + sender.username());
+            case LIKE_COMMENT -> LocalizationProvider.getMessage("notification.content.like_comment", "@" + sender.username());
+            case REPLY_COMMENT -> LocalizationProvider.getMessage("notification.content.reply_comment", "@" + sender.username());
+            case MENTION_COMMENT -> LocalizationProvider.getMessage("notification.content.mention_comment", "@" + sender.username());
+            case NEW_FOLLOWER -> LocalizationProvider.getMessage("notification.content.new_follower", "@" + sender.username());
+            case UN_FOLLOWER -> LocalizationProvider.getMessage("notification.content.un_follower", "@" + sender.username());
+            case REPORT_COMMENT -> LocalizationProvider.getMessage("notification.content.report_comment");
+            case REPORT_POST -> LocalizationProvider.getMessage("notification.content.report_post");
+            case COMMENT_PINNED -> LocalizationProvider.getMessage("notification.content.comment_pinned");
             case SYSTEM_MESSAGE -> notification.getContent();
         };
     }

--- a/src/main/java/org/phong/horizon/post/enums/BookmarkErrorEnums.java
+++ b/src/main/java/org/phong/horizon/post/enums/BookmarkErrorEnums.java
@@ -4,16 +4,20 @@ import lombok.Getter;
 
 @Getter
 public enum BookmarkErrorEnums {
-    BOOKMARK_NOT_FOUND("Bookmark not found"),
-    BOOKMARK_EXISTS("Bookmark already exists"),
-    BOOKMARK_NOT_OWNED("Bookmark not owned by user"),
-    BOOKMARK_NOT_SAVED("Bookmark not saved"),
-    BOOKMARK_NOT_DELETED("Bookmark not deleted");
+    BOOKMARK_NOT_FOUND("bookmark.error.not_found"),
+    BOOKMARK_EXISTS("bookmark.error.exists"),
+    BOOKMARK_NOT_OWNED("bookmark.error.not_owned"),
+    BOOKMARK_NOT_SAVED("bookmark.error.not_saved"),
+    BOOKMARK_NOT_DELETED("bookmark.error.not_deleted");
 
-    private final String message;
+    private final String messageKey;
 
-    BookmarkErrorEnums(String message) {
-        this.message = message;
+    BookmarkErrorEnums(String messageKey) {
+        this.messageKey = messageKey;
+    }
+
+    public String getMessage(Object... args) {
+        return org.phong.horizon.core.config.LocalizationProvider.getMessage(this.messageKey, args);
     }
 
 }

--- a/src/main/java/org/phong/horizon/post/enums/PostErrorEnums.java
+++ b/src/main/java/org/phong/horizon/post/enums/PostErrorEnums.java
@@ -5,37 +5,41 @@ import lombok.Getter;
 @Getter
 public enum PostErrorEnums {
     // Validation Errors
-    INVALID_POST_ID("POST_001", "Invalid post ID."),
-    INVALID_USER_ID("POST_002", "Invalid user ID."),
-    INVALID_VIDEO_URL("POST_003", "Video URL cannot be empty."),
-    INVALID_VISIBILITY("POST_004", "Visibility must be 'public', 'private', or 'friends'."),
-    INVALID_DURATION("POST_005", "Duration must be greater than 0."),
+    INVALID_POST_ID("POST_001", "post.error.invalid_post_id"),
+    INVALID_USER_ID("POST_002", "post.error.invalid_user_id"),
+    INVALID_VIDEO_URL("POST_003", "post.error.invalid_video_url"),
+    INVALID_VISIBILITY("POST_004", "post.error.invalid_visibility"),
+    INVALID_DURATION("POST_005", "post.error.invalid_duration"),
 
     // Permission Errors
-    POST_NOT_FOUND("POST_006", "Post not found."),
-    UNAUTHORIZED_POST_ACCESS("POST_007", "You do not have permission to access this post."),
-    UNAUTHORIZED_POST_UPDATE("POST_008", "You do not have permission to update this post."),
-    UNAUTHORIZED_POST_DELETE("POST_009", "You do not have permission to delete this post."),
+    POST_NOT_FOUND("POST_006", "post.error.post_not_found"),
+    UNAUTHORIZED_POST_ACCESS("POST_007", "post.error.unauthorized_access"),
+    UNAUTHORIZED_POST_UPDATE("POST_008", "post.error.unauthorized_update"),
+    UNAUTHORIZED_POST_DELETE("POST_009", "post.error.unauthorized_delete"),
 
     // Business Logic Errors
-    POST_CREATION_FAILED("POST_010", "Failed to create post. Please try again."),
-    POST_UPDATE_FAILED("POST_011", "Failed to update post. Please try again."),
-    POST_DELETION_FAILED("POST_012", "Failed to delete post. Please try again."),
-    TAG_LIMIT_EXCEEDED("POST_013", "You can only add up to 10 tags."),
-    POST_VIDEO_PROCESSING_ERROR("POST_014", "Error processing video. Please try again later."),
-    POST_ASSET_ALREADY_EXISTS("POST_015", "Post with asset already exists."),
-    POST_ASSET_NOT_FOUND("POST_016", "Post asset not found."),
+    POST_CREATION_FAILED("POST_010", "post.error.creation_failed"),
+    POST_UPDATE_FAILED("POST_011", "post.error.update_failed"),
+    POST_DELETION_FAILED("POST_012", "post.error.deletion_failed"),
+    TAG_LIMIT_EXCEEDED("POST_013", "post.error.tag_limit_exceeded"),
+    POST_VIDEO_PROCESSING_ERROR("POST_014", "post.error.video_processing_error"),
+    POST_ASSET_ALREADY_EXISTS("POST_015", "post.error.asset_already_exists"),
+    POST_ASSET_NOT_FOUND("POST_016", "post.error.asset_not_found"),
 
-    POST_CATEGORY_NOT_FOUND("POST_017", "Post category not found."),
-    POST_CATEGORY_EXISTS("POST_018", "Post category already exists."),;
+    POST_CATEGORY_NOT_FOUND("POST_017", "post.error.category_not_found"),
+    POST_CATEGORY_EXISTS("POST_018", "post.error.category_exists"),;
 
 
     private final String code;
-    private final String message;
+    private final String messageKey;
 
-    PostErrorEnums(String code, String message) {
+    PostErrorEnums(String code, String messageKey) {
         this.code = code;
-        this.message = message;
+        this.messageKey = messageKey;
+    }
+
+    public String getMessage(Object... args) {
+        return org.phong.horizon.core.config.LocalizationProvider.getMessage(this.messageKey, args);
     }
 }
 

--- a/src/main/java/org/phong/horizon/post/enums/PostInteractionError.java
+++ b/src/main/java/org/phong/horizon/post/enums/PostInteractionError.java
@@ -4,17 +4,21 @@ import lombok.Getter;
 
 @Getter
 public enum PostInteractionError {
-    POST_INTERACTION_EXISTS("Post interaction already exists"),
-    POST_INTERACTION_NOT_FOUND("Post interaction not found"),
-    POST_INTERACTION_INVALID("Invalid post interaction"),
-    POST_INTERACTION_NOT_AUTHORIZED("User is not authorized to perform this action"),
-    POST_INTERACTION_TOO_LONG("Post interaction exceeds the maximum allowed length"),
-    POST_INTERACTION_ALREADY_DELETED("This post interaction has already been deleted"),
-    POST_INTERACTION_UNAUTHORIZED_ACCESS("Access to the post interaction is denied");
+    POST_INTERACTION_EXISTS("post_interaction.error.exists"),
+    POST_INTERACTION_NOT_FOUND("post_interaction.error.not_found"),
+    POST_INTERACTION_INVALID("post_interaction.error.invalid"),
+    POST_INTERACTION_NOT_AUTHORIZED("post_interaction.error.not_authorized"),
+    POST_INTERACTION_TOO_LONG("post_interaction.error.too_long"),
+    POST_INTERACTION_ALREADY_DELETED("post_interaction.error.already_deleted"),
+    POST_INTERACTION_UNAUTHORIZED_ACCESS("post_interaction.error.unauthorized_access");
 
-    private final String message;
+    private final String messageKey;
 
-    PostInteractionError(String message) {
-        this.message = message;
+    PostInteractionError(String messageKey) {
+        this.messageKey = messageKey;
+    }
+
+    public String getMessage(Object... args) {
+        return org.phong.horizon.core.config.LocalizationProvider.getMessage(this.messageKey, args);
     }
 }

--- a/src/main/java/org/phong/horizon/report/enums/ReportErrorCode.java
+++ b/src/main/java/org/phong/horizon/report/enums/ReportErrorCode.java
@@ -6,14 +6,18 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum ReportErrorCode {
-    REPORT_NOT_FOUND("Report not found with ID: %s"),
-    INVALID_ITEM_TYPE("Invalid item type specified for the report."),
-    MISSING_POST_ID("Post ID is required when item type is POST."),
-    MISSING_COMMENT_ID("Comment ID is required when item type is COMMENT."),
-    MISSING_USER_ID("Reported User ID is required when item type is USER."),
-    CANNOT_REPORT_SELF("Users cannot report themselves."),
-    INVALID_STATUS_TRANSITION("Invalid status transition from %s to %s.");
+    REPORT_NOT_FOUND("report.error.not_found"),
+    INVALID_ITEM_TYPE("report.error.invalid_item_type"),
+    MISSING_POST_ID("report.error.missing_post_id"),
+    MISSING_COMMENT_ID("report.error.missing_comment_id"),
+    MISSING_USER_ID("report.error.missing_user_id"),
+    CANNOT_REPORT_SELF("report.error.cannot_report_self"),
+    INVALID_STATUS_TRANSITION("report.error.invalid_status_transition");
 
-    private final String message;
+    private final String messageKey;
+
+    public String getMessage(Object... args) {
+        return org.phong.horizon.core.config.LocalizationProvider.getMessage(this.messageKey, args);
+    }
 }
 

--- a/src/main/java/org/phong/horizon/storage/enums/StorageErrorEnums.java
+++ b/src/main/java/org/phong/horizon/storage/enums/StorageErrorEnums.java
@@ -4,19 +4,23 @@ import lombok.Getter;
 
 @Getter
 public enum StorageErrorEnums {
-    MISSING_ASSET_PROPERTIES("Required upload data (publicId, secureUrl, resourceType) is missing."),
-    ASSET_ALREADY_EXISTS("Asset already exists: "),
-    ASSET_NOT_FOUND("Asset not found with ID: "),
-    CLOUDINARY_DELETION_FAILED("Failed to delete asset from Cloudinary for ID: "),
-    UNEXPECTED_CLOUDINARY_ERROR("Unexpected error during Cloudinary deletion for ID: "),
-    DB_DELETION_FAILED("Failed to delete asset record from database for ID: "),
-    INVALID_PUBLIC_ID("Public ID cannot be null or blank for Cloudinary deletion."),
-    CLOUDINARY_SIGNATURE_FAILED("Could not generate upload signature.");
+    MISSING_ASSET_PROPERTIES("storage.error.missing_asset_properties"),
+    ASSET_ALREADY_EXISTS("storage.error.asset_already_exists"),
+    ASSET_NOT_FOUND("storage.error.asset_not_found"),
+    CLOUDINARY_DELETION_FAILED("storage.error.cloudinary_deletion_failed"),
+    UNEXPECTED_CLOUDINARY_ERROR("storage.error.unexpected_cloudinary_error"),
+    DB_DELETION_FAILED("storage.error.db_deletion_failed"),
+    INVALID_PUBLIC_ID("storage.error.invalid_public_id"),
+    CLOUDINARY_SIGNATURE_FAILED("storage.error.cloudinary_signature_failed");
 
-    private final String message;
+    private final String messageKey;
 
-    StorageErrorEnums(String message) {
-        this.message = message;
+    StorageErrorEnums(String messageKey) {
+        this.messageKey = messageKey;
+    }
+
+    public String getMessage(Object... args) {
+        return org.phong.horizon.core.config.LocalizationProvider.getMessage(this.messageKey, args);
     }
 
 }

--- a/src/main/java/org/phong/horizon/user/enums/UserErrorEnums.java
+++ b/src/main/java/org/phong/horizon/user/enums/UserErrorEnums.java
@@ -4,15 +4,19 @@ import lombok.Getter;
 
 @Getter
 public enum UserErrorEnums {
-    USER_NOT_FOUND("User not found"),
-    USER_PROFILE_NOT_FOUND("User profile not found"),
-    INVALID_SQL_QUERY("Invalid SQL query"),
-    PASSWORD_NOT_MATCHING("Passwords do not match"),
-    USER_ALREADY_EXISTS("User already exists");
+    USER_NOT_FOUND("user.error.not_found"),
+    USER_PROFILE_NOT_FOUND("user.error.profile_not_found"),
+    INVALID_SQL_QUERY("user.error.invalid_sql_query"),
+    PASSWORD_NOT_MATCHING("user.error.password_not_matching"),
+    USER_ALREADY_EXISTS("user.error.user_already_exists");
 
-    private final String message;
+    private final String messageKey;
 
-    UserErrorEnums(String message) {
-        this.message = message;
+    UserErrorEnums(String messageKey) {
+        this.messageKey = messageKey;
+    }
+
+    public String getMessage(Object... args) {
+        return org.phong.horizon.core.config.LocalizationProvider.getMessage(this.messageKey, args);
     }
 }

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -1,0 +1,125 @@
+# Default messages (English)
+system.validation_failed=Validation failed
+system.malformed_request=Malformed JSON request
+system.method_not_supported=Method not supported
+system.generic_error=An unexpected error occurred
+system.missing_parameter=Required parameter is missing
+system.data_integrity_violation=Operation cannot be completed due to a data conflict (e.g., duplicate entry or invalid reference).
+system.invalid_argument_type=Invalid argument type
+system.authentication_failed=Authentication failed
+system.access_denied=Access denied
+system.not_found_endpoint=Endpoint not found
+
+notification.error.not_found=Notification not found
+notification.error.access_denied=You do not have permission to access this notification
+notification.error.already_read=Notification already read
+notification.error.already_deleted=Notification already deleted
+notification.error.type_not_supported=Notification type not supported
+
+notification.content.like_post=@{0} liked your post.
+notification.content.comment_post=@{0} commented on your post.
+notification.content.like_comment=@{0} liked your comment.
+notification.content.reply_comment=@{0} replied to your comment.
+notification.content.mention_comment=@{0} mentioned you in a comment.
+notification.content.new_follower=@{0} followed you.
+notification.content.un_follower=@{0} unfollowed you.
+notification.content.report_comment=Your comment was reported.
+notification.content.report_post=Your post was reported.
+notification.content.comment_pinned=Your comment was pinned.
+
+bookmark.error.not_found=Bookmark not found
+bookmark.error.exists=Bookmark already exists
+bookmark.error.not_owned=Bookmark not owned by user
+bookmark.error.not_saved=Bookmark not saved
+bookmark.error.not_deleted=Bookmark not deleted
+
+comment.error.not_found=Comment not found
+comment.error.user_not_authorized=User is not authorized to perform this action
+comment.error.comment_too_long=Comment exceeds the maximum allowed length
+comment.error.invalid_format=Comment format is invalid
+comment.error.already_deleted=This comment has already been deleted
+comment.error.unauthorized_access=Access to the comment is denied
+comment.error.missing_content=Comment content cannot be empty
+comment.error.invalid_user=The user does not exist
+comment.error.already_pinned=Comment is already pinned
+comment.error.already_unpinned=Comment is already unpinned
+comment.success.pinned=Comment pinned successfully
+comment.success.unpinned=Comment unpinned successfully
+comment.success.deleted=Comment deleted successfully
+comment.success.reported=Comment reported successfully
+
+comment_interaction.error.exists=Comment interaction already exists
+comment_interaction.error.not_found=Comment interaction not found
+comment_interaction.error.invalid=Invalid comment interaction
+comment_interaction.error.not_authorized=User is not authorized to perform this action
+comment_interaction.error.too_long=Comment interaction exceeds the maximum allowed length
+comment_interaction.error.already_deleted=This comment interaction has already been deleted
+comment_interaction.error.unauthorized_access=Access to the comment interaction is denied
+
+follow.error.not_found=Follow not found
+follow.error.already_exists=Follow already exists
+follow.error.follower_not_found=Follower not found
+follow.error.following_not_found=Following not found
+follow.error.invalid_request=Invalid follow request
+follow.error.unable_follow_self=Unable to follow yourself
+follow.error.unable_unfollow_self=Unable to unfollow yourself
+follow.error.not_following=Not following
+
+history_activity.error.type_not_found=Activity type not found
+history_activity.error.code_not_found=Activity type code not found
+history_activity.error.code_invalid=Activity type code is invalid
+history_activity.error.code_duplicate=Activity type code is duplicate
+history_activity.error.name_duplicate=Activity type name is duplicate
+
+post.error.invalid_post_id=Invalid post ID.
+post.error.invalid_user_id=Invalid user ID.
+post.error.invalid_video_url=Video URL cannot be empty.
+post.error.invalid_visibility=Visibility must be 'public', 'private', or 'friends'.
+post.error.invalid_duration=Duration must be greater than 0.
+post.error.post_not_found=Post not found.
+post.error.unauthorized_access=You do not have permission to access this post.
+post.error.unauthorized_update=You do not have permission to update this post.
+post.error.unauthorized_delete=You do not have permission to delete this post.
+post.error.creation_failed=Failed to create post. Please try again.
+post.error.update_failed=Failed to update post. Please try again.
+post.error.deletion_failed=Failed to delete post. Please try again.
+post.error.tag_limit_exceeded=You can only add up to 10 tags.
+post.error.video_processing_error=Error processing video. Please try again later.
+post.error.asset_already_exists=Post with asset already exists.
+post.error.asset_not_found=Post asset not found.
+post.error.category_not_found=Post category not found.
+post.error.category_exists=Post category already exists.
+
+post_interaction.error.exists=Post interaction already exists
+post_interaction.error.not_found=Post interaction not found
+post_interaction.error.invalid=Invalid post interaction
+post_interaction.error.not_authorized=User is not authorized to perform this action
+post_interaction.error.too_long=Post interaction exceeds the maximum allowed length
+post_interaction.error.already_deleted=This post interaction has already been deleted
+post_interaction.error.unauthorized_access=Access to the post interaction is denied
+
+storage.error.missing_asset_properties=Required upload data (publicId, secureUrl, resourceType) is missing.
+storage.error.asset_already_exists=Asset already exists: 
+storage.error.asset_not_found=Asset not found with ID: 
+storage.error.cloudinary_deletion_failed=Failed to delete asset from Cloudinary for ID: 
+storage.error.unexpected_cloudinary_error=Unexpected error during Cloudinary deletion for ID: 
+storage.error.db_deletion_failed=Failed to delete asset record from database for ID: 
+storage.error.invalid_public_id=Public ID cannot be null or blank for Cloudinary deletion.
+storage.error.cloudinary_signature_failed=Could not generate upload signature.
+
+user.error.not_found=User not found
+user.error.profile_not_found=User profile not found
+user.error.invalid_sql_query=Invalid SQL query
+user.error.password_not_matching=Passwords do not match
+user.error.user_already_exists=User already exists
+
+report.error.not_found=Report not found with ID: %s
+report.error.invalid_item_type=Invalid item type specified for the report.
+report.error.missing_post_id=Post ID is required when item type is POST.
+report.error.missing_comment_id=Comment ID is required when item type is COMMENT.
+report.error.missing_user_id=Reported User ID is required when item type is USER.
+report.error.cannot_report_self=Users cannot report themselves.
+report.error.invalid_status_transition=Invalid status transition from %s to %s.
+
+admin.notification.error.not_found=Notification not found with id: %s
+admin.notification.error.invalid_data=Invalid notification data provided.

--- a/src/main/resources/messages_en.properties
+++ b/src/main/resources/messages_en.properties
@@ -1,0 +1,125 @@
+# Default messages (English)
+system.validation_failed=Validation failed
+system.malformed_request=Malformed JSON request
+system.method_not_supported=Method not supported
+system.generic_error=An unexpected error occurred
+system.missing_parameter=Required parameter is missing
+system.data_integrity_violation=Operation cannot be completed due to a data conflict (e.g., duplicate entry or invalid reference).
+system.invalid_argument_type=Invalid argument type
+system.authentication_failed=Authentication failed
+system.access_denied=Access denied
+system.not_found_endpoint=Endpoint not found
+
+notification.error.not_found=Notification not found
+notification.error.access_denied=You do not have permission to access this notification
+notification.error.already_read=Notification already read
+notification.error.already_deleted=Notification already deleted
+notification.error.type_not_supported=Notification type not supported
+
+notification.content.like_post=@{0} liked your post.
+notification.content.comment_post=@{0} commented on your post.
+notification.content.like_comment=@{0} liked your comment.
+notification.content.reply_comment=@{0} replied to your comment.
+notification.content.mention_comment=@{0} mentioned you in a comment.
+notification.content.new_follower=@{0} followed you.
+notification.content.un_follower=@{0} unfollowed you.
+notification.content.report_comment=Your comment was reported.
+notification.content.report_post=Your post was reported.
+notification.content.comment_pinned=Your comment was pinned.
+
+bookmark.error.not_found=Bookmark not found
+bookmark.error.exists=Bookmark already exists
+bookmark.error.not_owned=Bookmark not owned by user
+bookmark.error.not_saved=Bookmark not saved
+bookmark.error.not_deleted=Bookmark not deleted
+
+comment.error.not_found=Comment not found
+comment.error.user_not_authorized=User is not authorized to perform this action
+comment.error.comment_too_long=Comment exceeds the maximum allowed length
+comment.error.invalid_format=Comment format is invalid
+comment.error.already_deleted=This comment has already been deleted
+comment.error.unauthorized_access=Access to the comment is denied
+comment.error.missing_content=Comment content cannot be empty
+comment.error.invalid_user=The user does not exist
+comment.error.already_pinned=Comment is already pinned
+comment.error.already_unpinned=Comment is already unpinned
+comment.success.pinned=Comment pinned successfully
+comment.success.unpinned=Comment unpinned successfully
+comment.success.deleted=Comment deleted successfully
+comment.success.reported=Comment reported successfully
+
+comment_interaction.error.exists=Comment interaction already exists
+comment_interaction.error.not_found=Comment interaction not found
+comment_interaction.error.invalid=Invalid comment interaction
+comment_interaction.error.not_authorized=User is not authorized to perform this action
+comment_interaction.error.too_long=Comment interaction exceeds the maximum allowed length
+comment_interaction.error.already_deleted=This comment interaction has already been deleted
+comment_interaction.error.unauthorized_access=Access to the comment interaction is denied
+
+follow.error.not_found=Follow not found
+follow.error.already_exists=Follow already exists
+follow.error.follower_not_found=Follower not found
+follow.error.following_not_found=Following not found
+follow.error.invalid_request=Invalid follow request
+follow.error.unable_follow_self=Unable to follow yourself
+follow.error.unable_unfollow_self=Unable to unfollow yourself
+follow.error.not_following=Not following
+
+history_activity.error.type_not_found=Activity type not found
+history_activity.error.code_not_found=Activity type code not found
+history_activity.error.code_invalid=Activity type code is invalid
+history_activity.error.code_duplicate=Activity type code is duplicate
+history_activity.error.name_duplicate=Activity type name is duplicate
+
+post.error.invalid_post_id=Invalid post ID.
+post.error.invalid_user_id=Invalid user ID.
+post.error.invalid_video_url=Video URL cannot be empty.
+post.error.invalid_visibility=Visibility must be 'public', 'private', or 'friends'.
+post.error.invalid_duration=Duration must be greater than 0.
+post.error.post_not_found=Post not found.
+post.error.unauthorized_access=You do not have permission to access this post.
+post.error.unauthorized_update=You do not have permission to update this post.
+post.error.unauthorized_delete=You do not have permission to delete this post.
+post.error.creation_failed=Failed to create post. Please try again.
+post.error.update_failed=Failed to update post. Please try again.
+post.error.deletion_failed=Failed to delete post. Please try again.
+post.error.tag_limit_exceeded=You can only add up to 10 tags.
+post.error.video_processing_error=Error processing video. Please try again later.
+post.error.asset_already_exists=Post with asset already exists.
+post.error.asset_not_found=Post asset not found.
+post.error.category_not_found=Post category not found.
+post.error.category_exists=Post category already exists.
+
+post_interaction.error.exists=Post interaction already exists
+post_interaction.error.not_found=Post interaction not found
+post_interaction.error.invalid=Invalid post interaction
+post_interaction.error.not_authorized=User is not authorized to perform this action
+post_interaction.error.too_long=Post interaction exceeds the maximum allowed length
+post_interaction.error.already_deleted=This post interaction has already been deleted
+post_interaction.error.unauthorized_access=Access to the post interaction is denied
+
+storage.error.missing_asset_properties=Required upload data (publicId, secureUrl, resourceType) is missing.
+storage.error.asset_already_exists=Asset already exists: 
+storage.error.asset_not_found=Asset not found with ID: 
+storage.error.cloudinary_deletion_failed=Failed to delete asset from Cloudinary for ID: 
+storage.error.unexpected_cloudinary_error=Unexpected error during Cloudinary deletion for ID: 
+storage.error.db_deletion_failed=Failed to delete asset record from database for ID: 
+storage.error.invalid_public_id=Public ID cannot be null or blank for Cloudinary deletion.
+storage.error.cloudinary_signature_failed=Could not generate upload signature.
+
+user.error.not_found=User not found
+user.error.profile_not_found=User profile not found
+user.error.invalid_sql_query=Invalid SQL query
+user.error.password_not_matching=Passwords do not match
+user.error.user_already_exists=User already exists
+
+report.error.not_found=Report not found with ID: %s
+report.error.invalid_item_type=Invalid item type specified for the report.
+report.error.missing_post_id=Post ID is required when item type is POST.
+report.error.missing_comment_id=Comment ID is required when item type is COMMENT.
+report.error.missing_user_id=Reported User ID is required when item type is USER.
+report.error.cannot_report_self=Users cannot report themselves.
+report.error.invalid_status_transition=Invalid status transition from %s to %s.
+
+admin.notification.error.not_found=Notification not found with id: %s
+admin.notification.error.invalid_data=Invalid notification data provided.

--- a/src/main/resources/messages_vi.properties
+++ b/src/main/resources/messages_vi.properties
@@ -1,0 +1,124 @@
+system.validation_failed=\u0110\u00e3 c\u00f3 l\u1ed7i x\u00e1c th\u1ef1c
+system.malformed_request=Y\u00eau c\u1ea7u JSON kh\u00f4ng h\u1ee3p l\u1ec7
+system.method_not_supported=Ph\u01b0\u01a1ng th\u1ee9c kh\u00f4ng \u0111\u01b0\u1ee3c h\u1ed7 tr\u1ee3
+system.generic_error=C\u00f3 l\u1ed7i kh\u00f4ng x\u00e1c \u0111\u1ecbnh x\u1ea3y ra
+system.missing_parameter=Thi\u1ebfu tham s\u1ed1 b\u1eaft bu\u1ed9c
+system.data_integrity_violation=Kh\u00f4ng th\u1ec3 th\u1ef1c hi\u1ec7n do xung \u0111\u1ed9t d\u1eef li\u1ec7u
+system.invalid_argument_type=Ki\u1ec3u tham s\u1ed1 kh\u00f4ng h\u1ee3p l\u1ec7
+system.authentication_failed=X\u00e1c th\u1ef1c th\u1ea5t b\u1ea1i
+system.access_denied=T\u1eeb ch\u1ed1i truy c\u1eadp
+system.not_found_endpoint=Kh\u00f4ng t\u00ecm th\u1ea5y \u0111\u01b0\u1eddng d\u1eabn
+
+notification.error.not_found=Kh\u00f4ng t\u00ecm th\u1ea5y th\u00f4ng b\u00e1o
+notification.error.access_denied=B\u1ea1n kh\u00f4ng c\u00f3 quy\u1ec1n truy c\u1eadp th\u00f4ng b\u00e1o n\u00e0y
+notification.error.already_read=Th\u00f4ng b\u00e1o \u0111\u00e3 \u0111\u01b0\u1ee3c \u0111\u1ecdoc
+notification.error.already_deleted=Th\u00f4ng b\u00e1o \u0111\u00e3 xo\u00e1
+notification.error.type_not_supported=Lo\u1ea1i th\u00f4ng b\u00e1o kh\u00f4ng \u0111\u01b0\u1ee3c h\u1ed7 tr\u1ee3
+
+notification.content.like_post=@{0} th\u00edch b\u00e0i vi\u1ebft c\u1ee7a b\u1ea1n.
+notification.content.comment_post=@{0} \u0111\u00e3 b\u00ecnh lu\u1eadn v\u1ec1 b\u00e0i vi\u1ebft c\u1ee7a b\u1ea1n.
+notification.content.like_comment=@{0} th\u00edch b\u00ecnh lu\u1eadn c\u1ee7a b\u1ea1n.
+notification.content.reply_comment=@{0} \u0111\u00e3 ph\u1ea3n h\u1ed3i b\u00ecnh lu\u1eadn c\u1ee7a b\u1ea1n.
+notification.content.mention_comment=@{0} \u0111\u00e3 nh\u1eafc \u0111\u1ebfn b\u1ea1n trong m\u1ed9t b\u00ecnh lu\u1eadn.
+notification.content.new_follower=@{0} \u0111\u00e3 theo d\u00f5i b\u1ea1n.
+notification.content.un_follower=@{0} \u0111\u00e3 h\u1ee7y theo d\u00f5i b\u1ea1n.
+notification.content.report_comment=B\u00ecnh lu\u1eadn c\u1ee7a b\u1ea1n b\u1ecb b\u00e1o c\u00e1o.
+notification.content.report_post=B\u00e0i vi\u1ebft c\u1ee7a b\u1ea1n b\u1ecb b\u00e1o c\u00e1o.
+notification.content.comment_pinned=B\u00ecnh lu\u1eadn c\u1ee7a b\u1ea1n \u0111\u01b0\u1ee3c ghim.
+
+bookmark.error.not_found=Kh\u00f4ng t\u00ecm th\u1ea5y d\u1ea5u trang
+bookmark.error.exists=D\u1ea5u trang \u0111\u00e3 t\u1ed3n t\u1ea1i
+bookmark.error.not_owned=D\u1ea5u trang kh\u00f4ng thu\u1ed9c s\u1edf h\u1eefu c\u1ee7a b\u1ea1n
+bookmark.error.not_saved=D\u1ea5u trang ch\u01b0a \u0111\u01b0\u1ee3c l\u01b0u
+bookmark.error.not_deleted=D\u1ea5u trang ch\u01b0a \u0111\u01b0\u1ee3c xo\u00e1
+
+comment.error.not_found=Kh\u00f4ng t\u00ecm th\u1ea5y b\u00ecnh lu\u1eadn
+comment.error.user_not_authorized=Ng\u01b0\u1eddi d\u00f9ng kh\u00f4ng \u0111\u01b0\u1ee3c ph\u00e9p th\u1ef1c hi\u1ec7n h\u00e0nh \u0111\u1ed9ng n\u00e0y
+comment.error.comment_too_long=B\u00ecnh lu\u1eadn qu\u00e1 d\u00e0i
+comment.error.invalid_format=\u0110\u1ecbnh d\u1ea1ng b\u00ecnh lu\u1eadn kh\u00f4ng h\u1ee3p l\u1ec7
+comment.error.already_deleted=B\u00ecnh lu\u1eadn \u0111\u00e3 xo\u00e1
+comment.error.unauthorized_access=Kh\u00f4ng \u0111\u01b0\u1ee3c ph\u00e9p truy c\u1eadp b\u00ecnh lu\u1eadn
+comment.error.missing_content=N\u1ed9i dung b\u00ecnh lu\u1eadn kh\u00f4ng \u0111\u01b0\u1ee3c tr\u1ed1ng
+comment.error.invalid_user=Ng\u01b0\u1eddi d\u00f9ng kh\u00f4ng t\u1ed3n t\u1ea1i
+comment.error.already_pinned=B\u00ecnh lu\u1eadn \u0111\u00e3 \u0111\u01b0\u1ee3c ghim
+comment.error.already_unpinned=B\u00ecnh lu\u1eadn \u0111\u00e3 \u0111\u01b0\u1ee3c b\u1ecf ghim
+comment.success.pinned=Ghim b\u00ecnh lu\u1eadn th\u00e0nh c\u00f4ng
+comment.success.unpinned=B\u1ecf ghim b\u00ecnh lu\u1eadn th\u00e0nh c\u00f4ng
+comment.success.deleted=\u0110\u00e3 xo\u00e1 b\u00ecnh lu\u1eadn
+comment.success.reported=\u0110\u00e3 b\u00e1o c\u00e1o b\u00ecnh lu\u1eadn
+
+comment_interaction.error.exists=T\u01b0\u01a1ng t\u00e1c b\u00ecnh lu\u1eadn \u0111\u00e3 t\u1ed3n t\u1ea1i
+comment_interaction.error.not_found=Kh\u00f4ng t\u00ecm th\u1ea5y t\u01b0\u01a1ng t\u00e1c b\u00ecnh lu\u1eadn
+comment_interaction.error.invalid=T\u01b0\u01a1ng t\u00e1c b\u00ecnh lu\u1eadn kh\u00f4ng h\u1ee3p l\u1ec7
+comment_interaction.error.not_authorized=Ng\u01b0\u1eddi d\u00f9ng kh\u00f4ng \u0111\u01b0\u1ee3c ph\u00e9p th\u1ef1c hi\u1ec7n h\u00e0nh \u0111\u1ed9ng n\u00e0y
+comment_interaction.error.too_long=T\u01b0\u01a1ng t\u00e1c b\u00ecnh lu\u1eadn qu\u00e1 d\u00e0i
+comment_interaction.error.already_deleted=T\u01b0\u01a1ng t\u00e1c b\u00ecnh lu\u1eadn \u0111\u00e3 xo\u00e1
+comment_interaction.error.unauthorized_access=Kh\u00f4ng \u0111\u01b0\u1ee3c ph\u00e9p truy c\u1eadp t\u01b0\u01a1ng t\u00e1c b\u00ecnh lu\u1eadn
+
+follow.error.not_found=Kh\u00f4ng t\u00ecm th\u1ea5y theo d\u00f5i
+follow.error.already_exists=\u0110\u00e3 theo d\u00f5i
+follow.error.follower_not_found=Kh\u00f4ng t\u00ecm th\u1ea5y ng\u01b0\u1eddi theo d\u00f5i
+follow.error.following_not_found=Kh\u00f4ng t\u00ecm th\u1ea5y ng\u01b0\u1eddi \u0111\u01b0\u1ee3c theo d\u00f5i
+follow.error.invalid_request=Y\u00eau c\u1ea7u theo d\u00f5i kh\u00f4ng h\u1ee3p l\u1ec7
+follow.error.unable_follow_self=Kh\u00f4ng th\u1ec3 theo d\u00f5i ch\u00ednh m\u00ecnh
+follow.error.unable_unfollow_self=Kh\u00f4ng th\u1ec3 h\u1ee7y theo d\u00f5i ch\u00ednh m\u00ecnh
+follow.error.not_following=Ch\u01b0a theo d\u00f5i
+
+history_activity.error.type_not_found=Kh\u00f4ng t\u00ecm th\u1ea5y lo\u1ea1i ho\u1ea1t \u0111\u1ed9ng
+history_activity.error.code_not_found=Kh\u00f4ng t\u00ecm th\u1ea5y m\u00e3 ho\u1ea1t \u0111\u1ed9ng
+history_activity.error.code_invalid=M\u00e3 ho\u1ea1t \u0111\u1ed9ng kh\u00f4ng h\u1ee3p l\u1ec7
+history_activity.error.code_duplicate=M\u00e3 ho\u1ea1t \u0111\u1ed9ng tr\u00f9ng l\u1eb7p
+history_activity.error.name_duplicate=T\u00ean ho\u1ea1t \u0111\u1ed9ng tr\u00f9ng l\u1eb7p
+
+post.error.invalid_post_id=ID b\u00e0i vi\u1ebft kh\u00f4ng h\u1ee3p l\u1ec7.
+post.error.invalid_user_id=ID ng\u01b0\u1eddi d\u00f9ng kh\u00f4ng h\u1ee3p l\u1ec7.
+post.error.invalid_video_url=URL video kh\u00f4ng \u0111\u01b0\u1ee3c tr\u1ed1ng.
+post.error.invalid_visibility=Ch\u1ebf \u0111\u1ed9 hi\u1ec3n th\u1ecb ph\u1ea3i l\u00e0 'public', 'private' ho\u1eb7c 'friends'.
+post.error.invalid_duration=Th\u1eddi gian ph\u1ea3i l\u1edbn h\u01a1n 0.
+post.error.post_not_found=Kh\u00f4ng t\u00ecm th\u1ea5y b\u00e0i vi\u1ebft.
+post.error.unauthorized_access=B\u1ea1n kh\u00f4ng c\u00f3 quy\u1ec1n truy c\u1eadp b\u00e0i vi\u1ebft n\u00e0y.
+post.error.unauthorized_update=B\u1ea1n kh\u00f4ng c\u00f3 quy\u1ec1n c\u1eadp nh\u1eadt b\u00e0i vi\u1ebft n\u00e0y.
+post.error.unauthorized_delete=B\u1ea1n kh\u00f4ng c\u00f3 quy\u1ec1n xo\u00e1 b\u00e0i vi\u1ebft n\u00e0y.
+post.error.creation_failed=T\u1ea1o b\u00e0i vi\u1ebft th\u1ea5t b\u1ea1i. Vui l\u00f2ng th\u1eed l\u1ea1i.
+post.error.update_failed=C\u1eadp nh\u1eadt b\u00e0i vi\u1ebft th\u1ea5t b\u1ea1i. Vui l\u00f2ng th\u1eed l\u1ea1i.
+post.error.deletion_failed=Xo\u00e1 b\u00e0i vi\u1ebft th\u1ea5t b\u1ea1i. Vui l\u00f2ng th\u1eed l\u1ea1i.
+post.error.tag_limit_exceeded=Ch\u1ec9 c\u00f3 th\u1ec3 th\u00eam t\u1ed1i \u0111a 10 th\u1ebb.
+post.error.video_processing_error=X\u1eed l\u00fd video l\u1ed7i. Vui l\u00f2ng th\u1eed l\u1ea1i sau.
+post.error.asset_already_exists=B\u00e0i vi\u1ebft v\u1edbi t\u00e0i nguy\u00ean \u0111\u00e3 t\u1ed3n t\u1ea1i.
+post.error.asset_not_found=Kh\u00f4ng t\u00ecm th\u1ea5y t\u00e0i nguy\u00ean b\u00e0i vi\u1ebft.
+post.error.category_not_found=Kh\u00f4ng t\u00ecm th\u1ea5y danh m\u1ee5c b\u00e0i vi\u1ebft.
+post.error.category_exists=Danh m\u1ee5c b\u00e0i vi\u1ebft \u0111\u00e3 t\u1ed3n t\u1ea1i.
+
+post_interaction.error.exists=T\u01b0\u01a1ng t\u00e1c b\u00e0i vi\u1ebft \u0111\u00e3 t\u1ed3n t\u1ea1i
+post_interaction.error.not_found=Kh\u00f4ng t\u00ecm th\u1ea5y t\u01b0\u01a1ng t\u00e1c b\u00e0i vi\u1ebft
+post_interaction.error.invalid=T\u01b0\u01a1ng t\u00e1c b\u00e0i vi\u1ebft kh\u00f4ng h\u1ee3p l\u1ec7
+post_interaction.error.not_authorized=Ng\u01b0\u1eddi d\u00f9ng kh\u00f4ng \u0111\u01b0\u1ee3c ph\u00e9p th\u1ef1c hi\u1ec7n h\u00e0nh \u0111\u1ed9ng n\u00e0y
+post_interaction.error.too_long=T\u01b0\u01a1ng t\u00e1c b\u00e0i vi\u1ebft qu\u00e1 d\u00e0i
+post_interaction.error.already_deleted=T\u01b0\u01a1ng t\u00e1c b\u00e0i vi\u1ebft \u0111\u00e3 xo\u00e1
+post_interaction.error.unauthorized_access=Kh\u00f4ng \u0111\u01b0\u1ee3c ph\u00e9p truy c\u1eadp t\u01b0\u01a1ng t\u00e1c b\u00e0i vi\u1ebft
+
+storage.error.missing_asset_properties=Thi\u1ebfu th\u00f4ng tin t\u1ea3i l\u00ean (publicId, secureUrl, resourceType).
+storage.error.asset_already_exists=T\u00e0i nguy\u00ean \u0111\u00e3 t\u1ed3n t\u1ea1i:
+storage.error.asset_not_found=Kh\u00f4ng t\u00ecm th\u1ea5y t\u00e0i nguy\u00ean v\u1edbi ID:
+storage.error.cloudinary_deletion_failed=Xo\u00e1 t\u00e0i nguy\u00ean tr\u00ean Cloudinary th\u1ea5t b\u1ea1i v\u1edbi ID:
+storage.error.unexpected_cloudinary_error=L\u1ed7i kh\u00f4ng mong mu\u1ed1n khi xo\u00e1 Cloudinary ID:
+storage.error.db_deletion_failed=Xo\u00e1 b\u1ea3n ghi t\u1ea1i c\u01a1 s\u1edf d\u1eef li\u1ec7u th\u1ea5t b\u1ea1i v\u1edbi ID:
+storage.error.invalid_public_id=Public ID kh\u00f4ng \u0111\u01b0\u1ee3c \u0111\u1ec3 tr\u1ed1ng khi xo\u00e1 Cloudinary.
+storage.error.cloudinary_signature_failed=Kh\u00f4ng th\u1ec3 t\u1ea1o ch\u1ef1 k\u00fd t\u1ea3i l\u00ean.
+
+user.error.not_found=Kh\u00f4ng t\u00ecm th\u1ea5y ng\u01b0\u1eddi d\u00f9ng
+user.error.profile_not_found=Kh\u00f4ng t\u00ecm th\u1ea5y h\u1ed3 s\u01a1 ng\u01b0\u1eddi d\u00f9ng
+user.error.invalid_sql_query=C\u00e2u truy v\u1ea5n SQL kh\u00f4ng h\u1ee3p l\u1ec7
+user.error.password_not_matching=M\u1eadt kh\u1ea9u kh\u00f4ng kh\u1edbp
+user.error.user_already_exists=Ng\u01b0\u1eddi d\u00f9ng \u0111\u00e3 t\u1ed3n t\u1ea1i
+
+report.error.not_found=Kh\u00f4ng t\u00ecm th\u1ea5y b\u00e1o c\u00e1o v\u1edbi ID: %s
+report.error.invalid_item_type=Lo\u1ea1i \u0111\u1ed1i t\u01b0\u1ee3ng kh\u00f4ng h\u1ee3p l\u1ec7 cho b\u00e1o c\u00e1o.
+report.error.missing_post_id=Y\u00eau c\u1ea7u Post ID khi \u0111\u1ed1i t\u01b0\u1ee3ng l\u00e0 POST.
+report.error.missing_comment_id=Y\u00eau c\u1ea7u Comment ID khi \u0111\u1ed1i t\u01b0\u1ee3ng l\u00e0 COMMENT.
+report.error.missing_user_id=Y\u00eau c\u1ea7u User ID khi \u0111\u1ed1i t\u01b0\u1ee3ng l\u00e0 USER.
+report.error.cannot_report_self=Kh\u00f4ng th\u1ec3 b\u00e1o c\u00e1o ch\u00ednh m\u00ecnh.
+report.error.invalid_status_transition=Chuy\u1ec3n tr\u1ea1ng th\u00e1i t\u1eeb %s sang %s kh\u00f4ng h\u1ee3p l\u1ec7.
+
+admin.notification.error.not_found=Kh\u00f4ng t\u00ecm th\u1ea5y th\u00f4ng b\u00e1o id: %s
+admin.notification.error.invalid_data=D\u1eef li\u1ec7u th\u00f4ng b\u00e1o kh\u00f4ng h\u1ee3p l\u1ec7.


### PR DESCRIPTION
## Summary
- add Spring message source configuration and provider
- implement message bundles for English and Vietnamese
- convert error enums to return localized messages
- localize notification content generation

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_b_684eedf0c6608326b414fcec546e4e5c