### PR TITLE
Add channel batch events and listener

### DIFF
--- a/src/main/java/org/phong/horizon/ably/event/AblyBulkEvent.java
+++ b/src/main/java/org/phong/horizon/ably/event/AblyBulkEvent.java
@@ -1,0 +1,12 @@
+package org.phong.horizon.ably.event;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Marker interface describing a collection of publishable events grouped by channel.
+ */
+public interface AblyBulkEvent {
+    Map<String, List<AblyPublishableEvent>> getChannelEvents();
+}
+

--- a/src/main/java/org/phong/horizon/ably/event/AblyChannelMessagesEvent.java
+++ b/src/main/java/org/phong/horizon/ably/event/AblyChannelMessagesEvent.java
@@ -1,0 +1,12 @@
+package org.phong.horizon.ably.event;
+
+import java.util.List;
+
+/**
+ * Represents multiple Ably publishable events targeting a single channel.
+ */
+public interface AblyChannelMessagesEvent {
+    String getChannelName();
+
+    List<AblyPublishableEvent> getEvents();
+}

--- a/src/main/java/org/phong/horizon/ably/event/DefaultAblyBulkEvent.java
+++ b/src/main/java/org/phong/horizon/ably/event/DefaultAblyBulkEvent.java
@@ -1,0 +1,20 @@
+package org.phong.horizon.ably.event;
+
+import lombok.Getter;
+import org.springframework.context.ApplicationEvent;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Basic implementation of {@link AblyBulkEvent} to easily publish a map of channel events.
+ */
+@Getter
+public class DefaultAblyBulkEvent extends ApplicationEvent implements AblyBulkEvent {
+    private final Map<String, List<AblyPublishableEvent>> channelEvents;
+
+    public DefaultAblyBulkEvent(Object source, Map<String, List<AblyPublishableEvent>> channelEvents) {
+        super(source);
+        this.channelEvents = channelEvents;
+    }
+}

--- a/src/main/java/org/phong/horizon/ably/event/DefaultAblyChannelMessagesEvent.java
+++ b/src/main/java/org/phong/horizon/ably/event/DefaultAblyChannelMessagesEvent.java
@@ -1,0 +1,21 @@
+package org.phong.horizon.ably.event;
+
+import lombok.Getter;
+import org.springframework.context.ApplicationEvent;
+
+import java.util.List;
+
+/**
+ * Simple implementation of {@link AblyChannelMessagesEvent}.
+ */
+@Getter
+public class DefaultAblyChannelMessagesEvent extends ApplicationEvent implements AblyChannelMessagesEvent {
+    private final String channelName;
+    private final List<AblyPublishableEvent> events;
+
+    public DefaultAblyChannelMessagesEvent(Object source, String channelName, List<AblyPublishableEvent> events) {
+        super(source);
+        this.channelName = channelName;
+        this.events = events;
+    }
+}

--- a/src/main/java/org/phong/horizon/ably/listener/AblyEventListener.java
+++ b/src/main/java/org/phong/horizon/ably/listener/AblyEventListener.java
@@ -2,13 +2,24 @@ package org.phong.horizon.ably.listener;
 
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.phong.horizon.ably.event.AblyBulkEvent;
+import org.phong.horizon.ably.event.AblyChannelMessagesEvent;
 import org.phong.horizon.ably.event.AblyPublishableEvent;
 import org.phong.horizon.ably.service.AblyService;
+import org.phong.horizon.core.factories.GsonFactory;
 import org.phong.horizon.core.services.AuthService;
 import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionalEventListener;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import io.ably.lib.types.Message;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Component
@@ -16,6 +27,7 @@ import org.springframework.transaction.event.TransactionalEventListener;
 public class AblyEventListener {
     private final AblyService ablyService;
     private final AuthService authService;
+    private static final Gson gson = GsonFactory.create();
 
     @EventListener
     @Async("applicationTaskExecutor")
@@ -36,6 +48,56 @@ public class AblyEventListener {
         } catch (Exception e) {
             log.error("Error publishing message via AblyEventListener for channel: {}, event: {}: {}",
                     event.getChannelName(), event.getEventName(), e.getMessage(), e);
+        }
+    }
+
+    @EventListener
+    @Async("applicationTaskExecutor")
+    @TransactionalEventListener()
+    public void handleAblyBulkEvent(AblyBulkEvent bulkEvent) {
+        String clientIdForAbly = String.valueOf(authService.getUserIdFromContext());
+
+        Map<String, List<Message>> channelMessages = new HashMap<>();
+        bulkEvent.getChannelEvents().forEach((channel, events) -> {
+            List<Message> messages = events.stream().map(ev -> {
+                JsonElement messageDataJson = gson.toJsonTree(ev.getPayload());
+                Message m = new Message(ev.getEventName(), messageDataJson);
+                if (clientIdForAbly != null) {
+                    m.clientId = clientIdForAbly;
+                }
+                return m;
+            }).collect(Collectors.toList());
+            channelMessages.put(channel, messages);
+        });
+
+        try {
+            ablyService.publishToMultipleChannels(channelMessages);
+            log.debug("Successfully published bulk messages to Ably");
+        } catch (Exception e) {
+            log.error("Error publishing bulk messages via AblyEventListener: {}", e.getMessage(), e);
+        }
+    }
+
+    @EventListener
+    @Async("applicationTaskExecutor")
+    @TransactionalEventListener()
+    public void handleAblyChannelMessagesEvent(AblyChannelMessagesEvent event) {
+        String clientIdForAbly = String.valueOf(authService.getUserIdFromContext());
+
+        List<Message> messages = event.getEvents().stream().map(ev -> {
+            JsonElement messageDataJson = gson.toJsonTree(ev.getPayload());
+            Message m = new Message(ev.getEventName(), messageDataJson);
+            if (clientIdForAbly != null) {
+                m.clientId = clientIdForAbly;
+            }
+            return m;
+        }).collect(Collectors.toList());
+
+        try {
+            ablyService.publishMessages(event.getChannelName(), messages);
+            log.debug("Successfully published multiple messages to Ably channel: {}", event.getChannelName());
+        } catch (Exception e) {
+            log.error("Error publishing messages via AblyEventListener for channel {}: {}", event.getChannelName(), e.getMessage(), e);
         }
     }
 }


### PR DESCRIPTION
## Summary
- turn `AblyBulkEvent` into an interface
- add `DefaultAblyBulkEvent` implementing the interface
- introduce `AblyChannelMessagesEvent` and implementation for single-channel batches
- update listener to handle bulk and single-channel batch events

## Testing
- `./gradlew test --no-daemon` *(fails: unable to download Gradle wrapper)*

------
https://chatgpt.com/codex/tasks/task_b_684ff7fca6ac83268de0524fe346d20f