### PR TITLE
Enable caching for chart analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,8 @@ Redis is used for application caching. The application assumes a Redis instance
 is available at `localhost:6379`. When using a hosted Redis service, configure
 the connection with the `REDIS_HOST`, `REDIS_PORT`, and `REDIS_PASSWORD`
 environment variables.
+
+Certain analytics endpoints are cached to improve performance. Both the
+overview statistics (returning `List<OverviewStatistic>`) and chart data
+(daily count methods) are cached. Cached results expire after 10 minutes by
+default as configured in `RedisConfig`.

--- a/src/main/java/org/phong/horizon/analytics/services/AdminNotificationAnalyticsService.java
+++ b/src/main/java/org/phong/horizon/analytics/services/AdminNotificationAnalyticsService.java
@@ -7,6 +7,7 @@ import org.phong.horizon.admin.notification.infrastructure.entities.AdminNotific
 import org.phong.horizon.admin.notification.infrastructure.repositories.AdminNotificationRepository;
 import org.phong.horizon.analytics.dtos.DailyCountDto;
 import org.phong.horizon.analytics.dtos.OverviewStatistic;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -30,6 +31,7 @@ public class AdminNotificationAnalyticsService {
      * Get overview statistics for admin notifications
      */
     @Transactional
+    @Cacheable("admin-notification-overview")
     public List<OverviewStatistic> getAdminNotificationOverview() {
         ZoneId zone = ZoneOffset.UTC;
 

--- a/src/main/java/org/phong/horizon/analytics/services/CategoryAnalyticsService.java
+++ b/src/main/java/org/phong/horizon/analytics/services/CategoryAnalyticsService.java
@@ -8,6 +8,7 @@ import org.phong.horizon.post.subdomain.category.entities.PostCategory;
 import org.phong.horizon.post.subdomain.category.repositories.PostCategoryRepository;
 import org.phong.horizon.post.infrastructure.persistence.repositories.PostRepository;
 import org.phong.horizon.analytics.projections.TopCategoryUsageProjection;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -28,6 +29,7 @@ public class CategoryAnalyticsService {
      * Get overview statistics for categories
      */
     @Transactional(readOnly = true)
+    @Cacheable("category-overview")
     public List<OverviewStatistic> getCategoryAnalytics() {
         ZoneId zone = ZoneOffset.UTC;
 
@@ -104,6 +106,7 @@ public class CategoryAnalyticsService {
      * @return List of daily count DTOs with zeros for missing days
      */
     @Transactional(readOnly = true)
+    @Cacheable(value = "category-daily-counts", key = "#days")
     public List<DailyCountDto> getFilledDailyCategoryCounts(int days) {
         return getDailyCategoryCounts(days);
     }

--- a/src/main/java/org/phong/horizon/analytics/services/CommentAnalyticsService.java
+++ b/src/main/java/org/phong/horizon/analytics/services/CommentAnalyticsService.java
@@ -4,6 +4,7 @@ import lombok.AllArgsConstructor;
 import org.phong.horizon.analytics.dtos.DailyCountDto;
 import org.phong.horizon.analytics.dtos.OverviewStatistic;
 import org.phong.horizon.comment.infrastructure.persistence.repositories.CommentRepository;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,6 +24,7 @@ public class CommentAnalyticsService {
     private final CommentRepository commentRepository;
 
     @Transactional
+    @Cacheable("comment-overview")
     public List<OverviewStatistic> getCommentAnalytics() {
         long totalComments = commentRepository.count();
 
@@ -82,6 +84,7 @@ public class CommentAnalyticsService {
     }
 
     @Transactional
+    @Cacheable(value = "comment-daily-counts", key = "#days")
     public List<DailyCountDto> getFilledDailyCommentCounts(int days) {
         Instant from = Instant.now().minus(Duration.ofDays(days));
         List<Object[]> raw = commentRepository.countCommentsPerDay(from);

--- a/src/main/java/org/phong/horizon/analytics/services/DashboardAnalyticsService.java
+++ b/src/main/java/org/phong/horizon/analytics/services/DashboardAnalyticsService.java
@@ -5,6 +5,7 @@ import org.phong.horizon.analytics.dtos.DailyCountDto;
 import org.phong.horizon.analytics.dtos.OverviewStatistic;
 import org.phong.horizon.report.infrastructure.persistence.repositories.ReportRepository;
 import org.phong.horizon.user.infrastructure.persistence.repositories.UserRepository;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -33,6 +34,7 @@ public class DashboardAnalyticsService {
      * @return List of dashboard statistics for the main overview cards
      */
     @Transactional(readOnly = true)
+    @Cacheable("dashboard-overview")
     public List<OverviewStatistic> getDashboardOverview() {
         // Use UTC for consistent timezone handling
         ZoneId zone = ZoneOffset.UTC;
@@ -116,6 +118,7 @@ public class DashboardAnalyticsService {
      * @return List of daily user counts
      */
     @Transactional(readOnly = true)
+    @Cacheable(value = "dashboard-users-daily", key = "#days")
     public List<DailyCountDto> getUsersPerDay(int days) {
         // Reuse the UserAnalyticsService to get daily counts
         return userAnalyticsService.getFilledDailyUserCounts(days);
@@ -127,6 +130,7 @@ public class DashboardAnalyticsService {
      * @return List of daily post counts
      */
     @Transactional(readOnly = true)
+    @Cacheable(value = "dashboard-posts-daily", key = "#days")
     public List<DailyCountDto> getPostsPerDay(int days) {
         // Reuse the PostAnalyticsService to get daily counts
         return postAnalyticsService.getFilledDailyPostCounts(days);
@@ -138,6 +142,7 @@ public class DashboardAnalyticsService {
      * @return List of daily comment counts
      */
     @Transactional(readOnly = true)
+    @Cacheable(value = "dashboard-comments-daily", key = "#days")
     public List<DailyCountDto> getCommentsPerDay(int days) {
         // Reuse the CommentAnalyticsService to get daily counts
         return commentAnalyticsService.getFilledDailyCommentCounts(days);

--- a/src/main/java/org/phong/horizon/analytics/services/LogAnalyticsService.java
+++ b/src/main/java/org/phong/horizon/analytics/services/LogAnalyticsService.java
@@ -6,6 +6,7 @@ import org.phong.horizon.admin.logentry.infrastructure.entities.LogEntry;
 import org.phong.horizon.admin.logentry.infrastructure.repositories.LogEntryRepository;
 import org.phong.horizon.analytics.dtos.DailyCountDto;
 import org.phong.horizon.analytics.dtos.OverviewStatistic;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -31,6 +32,7 @@ public class LogAnalyticsService {
      * Get overview statistics for system logs
      */
     @Transactional
+    @Cacheable("log-overview")
     public List<OverviewStatistic> getLogOverviewStatistics() {
         ZoneId zone = ZoneOffset.UTC;
 

--- a/src/main/java/org/phong/horizon/analytics/services/ModerationReportAnalyticsService.java
+++ b/src/main/java/org/phong/horizon/analytics/services/ModerationReportAnalyticsService.java
@@ -6,6 +6,7 @@ import org.phong.horizon.analytics.dtos.OverviewStatistic;
 import org.phong.horizon.report.enums.ModerationItemType;
 import org.phong.horizon.report.enums.ModerationStatus;
 import org.phong.horizon.report.infrastructure.persistence.repositories.ReportRepository;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -27,6 +28,7 @@ public class ModerationReportAnalyticsService {
      * Get overview statistics for all moderation reports
      */
     @Transactional
+    @Cacheable(value = "moderation-overview", key = "'all'")
     public List<OverviewStatistic> getModerationOverviewStatistics() {
         return getModerationOverviewStatistics(null);
     }
@@ -36,6 +38,7 @@ public class ModerationReportAnalyticsService {
      * @param itemType The type of item to filter by (USER, POST, COMMENT), or null for all items
      */
     @Transactional
+    @Cacheable(value = "moderation-overview", key = "#itemType == null ? 'all' : #itemType.name()")
     public List<OverviewStatistic> getModerationOverviewStatistics(ModerationItemType itemType) {
         ZoneId zone = ZoneOffset.UTC;
 

--- a/src/main/java/org/phong/horizon/analytics/services/PostAnalyticsService.java
+++ b/src/main/java/org/phong/horizon/analytics/services/PostAnalyticsService.java
@@ -8,6 +8,7 @@ import org.phong.horizon.post.infrastructure.persistence.repositories.PostReposi
 import org.phong.horizon.post.infrastructure.persistence.repositories.ViewRepository;
 import org.phong.horizon.report.enums.ModerationItemType;
 import org.phong.horizon.report.infrastructure.persistence.repositories.ReportRepository;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,6 +27,7 @@ public class PostAnalyticsService {
     private final PostInteractionRepository postInteractionRepository;
 
     @Transactional
+    @Cacheable("post-overview")
     public List<OverviewStatistic> getPostAnalytics() {
         long totalPosts = postRepository.count();
 
@@ -85,6 +87,7 @@ public class PostAnalyticsService {
     }
 
     @Transactional
+    @Cacheable(value = "post-daily-counts", key = "#days")
     public List<DailyCountDto> getFilledDailyPostCounts(int days) {
         Instant from = Instant.now().minus(Duration.ofDays(days));
         List<Object[]> raw = postRepository.countPostsPerDay(from);

--- a/src/main/java/org/phong/horizon/analytics/services/TagAnalyticsService.java
+++ b/src/main/java/org/phong/horizon/analytics/services/TagAnalyticsService.java
@@ -7,6 +7,7 @@ import org.phong.horizon.analytics.dtos.TopTagUsageDTO;
 import org.phong.horizon.analytics.projections.TopTagUsageProjection;
 import org.phong.horizon.post.subdomain.tag.entity.Tag;
 import org.phong.horizon.post.subdomain.tag.repository.TagRepository;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,6 +27,7 @@ public class TagAnalyticsService {
      * Get overview statistics for tags
      */
     @Transactional(readOnly = true)
+    @Cacheable("tag-overview")
     public List<OverviewStatistic> getTagAnalytics() {
         ZoneId zone = ZoneOffset.UTC;
 
@@ -89,6 +91,7 @@ public class TagAnalyticsService {
      * @return List of daily tag counts
      */
     @Transactional(readOnly = true)
+    @Cacheable(value = "tag-daily-counts", key = "#days")
     public List<DailyCountDto> getDailyTagCounts(int days) {
         Instant startDate = LocalDate.now().minusDays(days - 1).atStartOfDay(ZoneOffset.UTC).toInstant();
         List<Object[]> results = tagRepository.countTagsPerDay(startDate);

--- a/src/main/java/org/phong/horizon/analytics/services/UserAnalyticsService.java
+++ b/src/main/java/org/phong/horizon/analytics/services/UserAnalyticsService.java
@@ -4,6 +4,7 @@ import lombok.AllArgsConstructor;
 import org.phong.horizon.analytics.dtos.OverviewStatistic;
 import org.phong.horizon.analytics.dtos.DailyCountDto;
 import org.phong.horizon.user.infrastructure.persistence.repositories.UserRepository;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,6 +20,7 @@ public class UserAnalyticsService {
     private final UserRepository userRepository;
 
     @Transactional
+    @Cacheable("user-overview")
     public List<OverviewStatistic> getUserAnalytics() {
         long totalUsers = userRepository.count();
 
@@ -76,6 +78,7 @@ public class UserAnalyticsService {
     }
 
     @Transactional
+    @Cacheable(value = "user-daily-counts", key = "#days")
     public List<DailyCountDto> getFilledDailyUserCounts(int days) {
         Instant from = Instant.now().minus(Duration.ofDays(days));
         List<Object[]> raw = userRepository.countUsersPerDay(from);


### PR DESCRIPTION
## Summary
- cache daily count methods for post, comment, user, category, tag analytics
- cache dashboard analytics overview and daily endpoints
- cache overview endpoints returning `List<OverviewStatistic>`
- document analytics cache in README

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_b_6852694c76d8832684ac2f0e42bd0898