### PR TITLE
Localize dashboard analytics overview

### DIFF
--- a/src/main/java/org/phong/horizon/analytics/services/AdminNotificationAnalyticsService.java
+++ b/src/main/java/org/phong/horizon/analytics/services/AdminNotificationAnalyticsService.java
@@ -7,6 +7,7 @@ import org.phong.horizon.admin.notification.infrastructure.entities.AdminNotific
 import org.phong.horizon.admin.notification.infrastructure.repositories.AdminNotificationRepository;
 import org.phong.horizon.analytics.dtos.DailyCountDto;
 import org.phong.horizon.analytics.dtos.OverviewStatistic;
+import org.phong.horizon.core.services.LocalizationProvider;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -65,32 +66,40 @@ public class AdminNotificationAnalyticsService {
 
         return List.of(
             new OverviewStatistic(
-                "Unread Notifications",
+                LocalizationProvider.getMessage("analytics.admin_notifications.unread.title"),
                 String.valueOf(unreadNotifications),
                 unreadTrend,
-                unreadTrend > 0 ? "More unread items than yesterday" : "Fewer unread items than yesterday",
-                "Notifications requiring admin attention"
+                unreadTrend > 0
+                        ? LocalizationProvider.getMessage("analytics.admin_notifications.unread.message.more")
+                        : LocalizationProvider.getMessage("analytics.admin_notifications.unread.message.fewer"),
+                LocalizationProvider.getMessage("analytics.admin_notifications.unread.description")
             ),
             new OverviewStatistic(
-                "Critical Alerts",
+                LocalizationProvider.getMessage("analytics.admin_notifications.critical.title"),
                 String.valueOf(criticalAlerts),
                 criticalTrend,
-                criticalTrend > 0 ? "Increase in critical alerts" : "Decrease in critical alerts",
-                "High priority notifications needing action"
+                criticalTrend > 0
+                        ? LocalizationProvider.getMessage("analytics.admin_notifications.critical.message.more")
+                        : LocalizationProvider.getMessage("analytics.admin_notifications.critical.message.fewer"),
+                LocalizationProvider.getMessage("analytics.admin_notifications.critical.description")
             ),
             new OverviewStatistic(
-                "System Issues (7d)",
+                LocalizationProvider.getMessage("analytics.admin_notifications.system_issues.title"),
                 String.valueOf(systemIssues),
                 systemIssuesTrend,
-                systemIssuesTrend > 0 ? "More system issues than last week" : "Fewer system issues than last week",
-                "Errors and warnings from system in last 7 days"
+                systemIssuesTrend > 0
+                        ? LocalizationProvider.getMessage("analytics.admin_notifications.system_issues.message.more")
+                        : LocalizationProvider.getMessage("analytics.admin_notifications.system_issues.message.fewer"),
+                LocalizationProvider.getMessage("analytics.admin_notifications.system_issues.description")
             ),
             new OverviewStatistic(
-                "New Reports (24h)",
+                LocalizationProvider.getMessage("analytics.admin_notifications.new_reports.title"),
                 String.valueOf(newReports),
                 newReportsTrend,
-                newReportsTrend > 0 ? "Increase in reports from previous day" : "Decrease in reports from previous day",
-                "User reports received in the last 24 hours"
+                newReportsTrend > 0
+                        ? LocalizationProvider.getMessage("analytics.admin_notifications.new_reports.message.increase")
+                        : LocalizationProvider.getMessage("analytics.admin_notifications.new_reports.message.decrease"),
+                LocalizationProvider.getMessage("analytics.admin_notifications.new_reports.description")
             )
         );
     }

--- a/src/main/java/org/phong/horizon/analytics/services/CategoryAnalyticsService.java
+++ b/src/main/java/org/phong/horizon/analytics/services/CategoryAnalyticsService.java
@@ -3,6 +3,7 @@ package org.phong.horizon.analytics.services;
 import lombok.AllArgsConstructor;
 import org.phong.horizon.analytics.dtos.DailyCountDto;
 import org.phong.horizon.analytics.dtos.OverviewStatistic;
+import org.phong.horizon.core.services.LocalizationProvider;
 import org.phong.horizon.analytics.dtos.TopCategoryUsageDTO;
 import org.phong.horizon.post.subdomain.category.entities.PostCategory;
 import org.phong.horizon.post.subdomain.category.repositories.PostCategoryRepository;
@@ -56,32 +57,38 @@ public class CategoryAnalyticsService {
 
         return List.of(
             new OverviewStatistic(
-                "Total Categories",
+                LocalizationProvider.getMessage("analytics.category.total.title"),
                 String.valueOf(totalCategories),
                 categoryTrend,
-                categoryTrend > 0 ? "Growing" : "Stable",
-                "Total number of categories in the system"
+                categoryTrend > 0
+                        ? LocalizationProvider.getMessage("analytics.category.total.message.growing")
+                        : LocalizationProvider.getMessage("analytics.category.total.message.stable"),
+                LocalizationProvider.getMessage("analytics.category.total.description")
             ),
             new OverviewStatistic(
-                "Most Used Category",
+                LocalizationProvider.getMessage("analytics.category.most_used.title"),
                 mostUsedCategoryName,
                 0.0,
-                String.format("Used in %d posts", mostUsedCategoryCount),
-                "Category with the most posts assigned"
+                LocalizationProvider.getMessage("analytics.category.most_used.message", mostUsedCategoryCount),
+                LocalizationProvider.getMessage("analytics.category.most_used.description")
             ),
             new OverviewStatistic(
-                "Unused Categories",
+                LocalizationProvider.getMessage("analytics.category.unused.title"),
                 String.valueOf(unusedCategories),
                 0.0,
-                unusedCategories > 0 ? "Candidates for cleanup" : "All categories in use",
-                "Categories without any posts"
+                unusedCategories > 0
+                        ? LocalizationProvider.getMessage("analytics.category.unused.message.cleanup")
+                        : LocalizationProvider.getMessage("analytics.category.unused.message.in_use"),
+                LocalizationProvider.getMessage("analytics.category.unused.description")
             ),
             new OverviewStatistic(
-                "New Categories Today",
+                LocalizationProvider.getMessage("analytics.category.new_today.title"),
                 String.valueOf(categoriesToday),
                 categoryTrend,
-                categoriesToday > 0 ? "Active category creation" : "No new categories today",
-                "Categories created in the last 24 hours"
+                categoriesToday > 0
+                        ? LocalizationProvider.getMessage("analytics.category.new_today.message.active")
+                        : LocalizationProvider.getMessage("analytics.category.new_today.message.none"),
+                LocalizationProvider.getMessage("analytics.category.new_today.description")
             )
         );
     }

--- a/src/main/java/org/phong/horizon/analytics/services/CommentAnalyticsService.java
+++ b/src/main/java/org/phong/horizon/analytics/services/CommentAnalyticsService.java
@@ -3,6 +3,7 @@ package org.phong.horizon.analytics.services;
 import lombok.AllArgsConstructor;
 import org.phong.horizon.analytics.dtos.DailyCountDto;
 import org.phong.horizon.analytics.dtos.OverviewStatistic;
+import org.phong.horizon.core.services.LocalizationProvider;
 import org.phong.horizon.comment.infrastructure.persistence.repositories.CommentRepository;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
@@ -53,32 +54,34 @@ public class CommentAnalyticsService {
 
         return List.of(
                 new OverviewStatistic(
-                        "Total Comments",
+                        LocalizationProvider.getMessage("analytics.comment.total.title"),
                         String.valueOf(totalComments),
                         6.3,
-                        "Healthy engagement",
-                        "All-time total comments"
+                        LocalizationProvider.getMessage("analytics.comment.total.message"),
+                        LocalizationProvider.getMessage("analytics.comment.total.description")
                 ),
                 new OverviewStatistic(
-                        "Comments Today",
+                        LocalizationProvider.getMessage("analytics.comment.today.title"),
                         String.valueOf(commentsToday),
                         commentTrend,
-                        commentTrend > 0 ? "Up from yesterday" : "Down from yesterday",
-                        "Activity in the past 24h"
+                        commentTrend > 0
+                                ? LocalizationProvider.getMessage("analytics.comment.today.message.up")
+                                : LocalizationProvider.getMessage("analytics.comment.today.message.down"),
+                        LocalizationProvider.getMessage("analytics.comment.today.description")
                 ),
                 new OverviewStatistic(
-                        "Reported Comments",
+                        LocalizationProvider.getMessage("analytics.comment.reported.title"),
                         String.valueOf(reportedComments),
                         -4.2,
-                        "Moderation load easing",
-                        "Comments flagged for review"
+                        LocalizationProvider.getMessage("analytics.comment.reported.message"),
+                        LocalizationProvider.getMessage("analytics.comment.reported.description")
                 ),
                 new OverviewStatistic(
-                        "Avg. Comments/Post",
+                        LocalizationProvider.getMessage("analytics.comment.avg_per_post.title"),
                         String.valueOf(roundedAvgCommentsPerPost),
                         1.8,
-                        "Steady interactions",
-                        "Engagement over the past 7 days"
+                        LocalizationProvider.getMessage("analytics.comment.avg_per_post.message"),
+                        LocalizationProvider.getMessage("analytics.comment.avg_per_post.description")
                 )
         );
     }

--- a/src/main/java/org/phong/horizon/analytics/services/DashboardAnalyticsService.java
+++ b/src/main/java/org/phong/horizon/analytics/services/DashboardAnalyticsService.java
@@ -5,6 +5,7 @@ import org.phong.horizon.analytics.dtos.DailyCountDto;
 import org.phong.horizon.analytics.dtos.OverviewStatistic;
 import org.phong.horizon.report.infrastructure.persistence.repositories.ReportRepository;
 import org.phong.horizon.user.infrastructure.persistence.repositories.UserRepository;
+import org.phong.horizon.core.services.LocalizationProvider;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -82,32 +83,38 @@ public class DashboardAnalyticsService {
 
         return List.of(
             new OverviewStatistic(
-                "Total Users",
+                LocalizationProvider.getMessage("analytics.dashboard.total_users.title"),
                 String.valueOf(totalUsers),
                 userTrend,
-                userTrend > 0 ? "Up " + formatTrend(userTrend) + "% this month" : "Down " + formatTrend(-userTrend) + "% this month",
-                "User growth over the last 30 days"
+                userTrend > 0
+                        ? LocalizationProvider.getMessage("analytics.dashboard.total_users.message.up", formatTrend(userTrend))
+                        : LocalizationProvider.getMessage("analytics.dashboard.total_users.message.down", formatTrend(-userTrend)),
+                LocalizationProvider.getMessage("analytics.dashboard.total_users.description")
             ),
             new OverviewStatistic(
-                "Total Posts",
+                LocalizationProvider.getMessage("analytics.dashboard.total_posts.title"),
                 String.valueOf(totalPosts),
                 postTrend,
-                "Steady content creation",
-                "Posts uploaded in the last 30 days"
+                LocalizationProvider.getMessage("analytics.dashboard.total_posts.message"),
+                LocalizationProvider.getMessage("analytics.dashboard.total_posts.description")
             ),
             new OverviewStatistic(
-                "Active Users",
+                LocalizationProvider.getMessage("analytics.dashboard.active_users.title"),
                 String.valueOf(activeUsers),
                 activeUsersTrend,
-                activeUsersTrend > 8 ? "High engagement this week" : "Normal engagement levels",
-                "Users active in the last 7 days"
+                activeUsersTrend > 8
+                        ? LocalizationProvider.getMessage("analytics.dashboard.active_users.message.high")
+                        : LocalizationProvider.getMessage("analytics.dashboard.active_users.message.normal"),
+                LocalizationProvider.getMessage("analytics.dashboard.active_users.description")
             ),
             new OverviewStatistic(
-                "Pending Reports",
+                LocalizationProvider.getMessage("analytics.dashboard.pending_reports.title"),
                 String.valueOf(pendingReports),
                 reportsTrend,
-                reportsTrend > 0 ? "Fewer reports than last week" : "More reports than last week",
-                "Reports requiring admin review"
+                reportsTrend > 0
+                        ? LocalizationProvider.getMessage("analytics.dashboard.pending_reports.message.fewer")
+                        : LocalizationProvider.getMessage("analytics.dashboard.pending_reports.message.more"),
+                LocalizationProvider.getMessage("analytics.dashboard.pending_reports.description")
             )
         );
     }

--- a/src/main/java/org/phong/horizon/analytics/services/LogAnalyticsService.java
+++ b/src/main/java/org/phong/horizon/analytics/services/LogAnalyticsService.java
@@ -6,6 +6,7 @@ import org.phong.horizon.admin.logentry.infrastructure.entities.LogEntry;
 import org.phong.horizon.admin.logentry.infrastructure.repositories.LogEntryRepository;
 import org.phong.horizon.analytics.dtos.DailyCountDto;
 import org.phong.horizon.analytics.dtos.OverviewStatistic;
+import org.phong.horizon.core.services.LocalizationProvider;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
@@ -65,32 +66,40 @@ public class LogAnalyticsService {
 
         return List.of(
             new OverviewStatistic(
-                "Error Logs Today",
+                LocalizationProvider.getMessage("analytics.log.errors_today.title"),
                 String.valueOf(errorLogsToday),
                 errorLogsTrend,
-                errorLogsTrend > 0 ? "More errors than yesterday" : "Fewer errors than yesterday",
-                "Error-level logs recorded today"
+                errorLogsTrend > 0
+                        ? LocalizationProvider.getMessage("analytics.log.errors_today.message.more")
+                        : LocalizationProvider.getMessage("analytics.log.errors_today.message.fewer"),
+                LocalizationProvider.getMessage("analytics.log.errors_today.description")
             ),
             new OverviewStatistic(
-                "Critical Logs Today",
+                LocalizationProvider.getMessage("analytics.log.critical_today.title"),
                 String.valueOf(criticalLogsToday),
                 criticalLogsTrend,
-                criticalLogsTrend > 0 ? "More critical issues than yesterday" : "Fewer critical issues than yesterday",
-                "Critical-level logs recorded today"
+                criticalLogsTrend > 0
+                        ? LocalizationProvider.getMessage("analytics.log.critical_today.message.more")
+                        : LocalizationProvider.getMessage("analytics.log.critical_today.message.fewer"),
+                LocalizationProvider.getMessage("analytics.log.critical_today.description")
             ),
             new OverviewStatistic(
-                "Error Logs (7d)",
+                LocalizationProvider.getMessage("analytics.log.errors_week.title"),
                 String.valueOf(errorLogsWeek),
                 errorLogsWeekTrend,
-                errorLogsWeekTrend > 0 ? "Increase from previous week" : "Decrease from previous week",
-                "Total error logs in the last 7 days"
+                errorLogsWeekTrend > 0
+                        ? LocalizationProvider.getMessage("analytics.log.errors_week.message.increase")
+                        : LocalizationProvider.getMessage("analytics.log.errors_week.message.decrease"),
+                LocalizationProvider.getMessage("analytics.log.errors_week.description")
             ),
             new OverviewStatistic(
-                "Critical Logs (7d)",
+                LocalizationProvider.getMessage("analytics.log.critical_week.title"),
                 String.valueOf(criticalLogsWeek),
                 criticalLogsWeekTrend,
-                criticalLogsWeekTrend > 0 ? "Increase from previous week" : "Decrease from previous week",
-                "Total critical logs in the last 7 days"
+                criticalLogsWeekTrend > 0
+                        ? LocalizationProvider.getMessage("analytics.log.critical_week.message.increase")
+                        : LocalizationProvider.getMessage("analytics.log.critical_week.message.decrease"),
+                LocalizationProvider.getMessage("analytics.log.critical_week.description")
             )
         );
     }

--- a/src/main/java/org/phong/horizon/analytics/services/ModerationReportAnalyticsService.java
+++ b/src/main/java/org/phong/horizon/analytics/services/ModerationReportAnalyticsService.java
@@ -3,6 +3,7 @@ package org.phong.horizon.analytics.services;
 import lombok.AllArgsConstructor;
 import org.phong.horizon.analytics.dtos.DailyPendingAndResolvedDto;
 import org.phong.horizon.analytics.dtos.OverviewStatistic;
+import org.phong.horizon.core.services.LocalizationProvider;
 import org.phong.horizon.report.enums.ModerationItemType;
 import org.phong.horizon.report.enums.ModerationStatus;
 import org.phong.horizon.report.infrastructure.persistence.repositories.ReportRepository;
@@ -89,32 +90,40 @@ public class ModerationReportAnalyticsService {
 
         return List.of(
                 new OverviewStatistic(
-                        titlePrefix + "Pending Reports",
+                        titlePrefix + LocalizationProvider.getMessage("analytics.moderation.pending.title"),
                         String.valueOf(pendingReports),
                         pendingReportsTrend,
-                        pendingReportsTrend < 0 ? "Fewer reports than last week" : "More reports than last week",
-                        titlePrefix + "Reports requiring admin review"
+                        pendingReportsTrend < 0
+                                ? LocalizationProvider.getMessage("analytics.moderation.pending.message.fewer")
+                                : LocalizationProvider.getMessage("analytics.moderation.pending.message.more"),
+                        titlePrefix + LocalizationProvider.getMessage("analytics.moderation.pending.description")
                 ),
                 new OverviewStatistic(
-                        titlePrefix + "Resolved Today",
+                        titlePrefix + LocalizationProvider.getMessage("analytics.moderation.resolved_today.title"),
                         String.valueOf(resolvedToday),
                         resolvedTrend,
-                        resolvedTrend > 0 ? "More resolutions than yesterday" : "Fewer resolutions than yesterday",
-                        titlePrefix + "Reports actioned and resolved today"
+                        resolvedTrend > 0
+                                ? LocalizationProvider.getMessage("analytics.moderation.resolved_today.message.more")
+                                : LocalizationProvider.getMessage("analytics.moderation.resolved_today.message.fewer"),
+                        titlePrefix + LocalizationProvider.getMessage("analytics.moderation.resolved_today.description")
                 ),
                 new OverviewStatistic(
-                        titlePrefix + "Content Removed (7d)",
+                        titlePrefix + LocalizationProvider.getMessage("analytics.moderation.content_removed.title"),
                         String.valueOf(contentRemoved),
                         contentRemovedTrend,
-                        contentRemovedTrend > 0 ? "Increase in content takedowns" : "Decrease in content takedowns",
-                        titlePrefix + "Posts/Comments removed in the last 7 days"
+                        contentRemovedTrend > 0
+                                ? LocalizationProvider.getMessage("analytics.moderation.content_removed.message.increase")
+                                : LocalizationProvider.getMessage("analytics.moderation.content_removed.message.decrease"),
+                        titlePrefix + LocalizationProvider.getMessage("analytics.moderation.content_removed.description")
                 ),
                 new OverviewStatistic(
-                        titlePrefix + "Users Actioned (7d)",
+                        titlePrefix + LocalizationProvider.getMessage("analytics.moderation.users_actioned.title"),
                         String.valueOf(usersActioned),
                         usersActionedTrend,
-                        usersActionedTrend < 0 ? "Fewer user actions this week" : "More user actions this week",
-                        titlePrefix + "Users warned or banned in the last 7 days"
+                        usersActionedTrend < 0
+                                ? LocalizationProvider.getMessage("analytics.moderation.users_actioned.message.fewer")
+                                : LocalizationProvider.getMessage("analytics.moderation.users_actioned.message.more"),
+                        titlePrefix + LocalizationProvider.getMessage("analytics.moderation.users_actioned.description")
                 )
         );
     }

--- a/src/main/java/org/phong/horizon/analytics/services/PostAnalyticsService.java
+++ b/src/main/java/org/phong/horizon/analytics/services/PostAnalyticsService.java
@@ -3,6 +3,7 @@ package org.phong.horizon.analytics.services;
 import lombok.AllArgsConstructor;
 import org.phong.horizon.analytics.dtos.DailyCountDto;
 import org.phong.horizon.analytics.dtos.OverviewStatistic;
+import org.phong.horizon.core.services.LocalizationProvider;
 import org.phong.horizon.post.infrastructure.persistence.repositories.PostInteractionRepository;
 import org.phong.horizon.post.infrastructure.persistence.repositories.PostRepository;
 import org.phong.horizon.post.infrastructure.persistence.repositories.ViewRepository;
@@ -56,32 +57,34 @@ public class PostAnalyticsService {
 
         return List.of(
                 new OverviewStatistic(
-                        "Total Posts",
+                        LocalizationProvider.getMessage("analytics.post.total.title"),
                         String.valueOf(totalPosts),
                         4.1,
-                        "Steady content growth",
-                        "Total posts uploaded to date"
+                        LocalizationProvider.getMessage("analytics.post.total.message"),
+                        LocalizationProvider.getMessage("analytics.post.total.description")
                 ),
                 new OverviewStatistic(
-                        "Posts Today",
+                        LocalizationProvider.getMessage("analytics.post.today.title"),
                         String.valueOf(postsToday),
                         postTrend,
-                        postTrend >= 0 ? "Slight increase from yesterday" : "Drop compared to yesterday",
-                        "Posts created in the last 24 hours"
+                        postTrend >= 0
+                                ? LocalizationProvider.getMessage("analytics.post.today.message.up")
+                                : LocalizationProvider.getMessage("analytics.post.today.message.down"),
+                        LocalizationProvider.getMessage("analytics.post.today.description")
                 ),
                 new OverviewStatistic(
-                        "Reported Posts",
+                        LocalizationProvider.getMessage("analytics.post.reported.title"),
                         String.valueOf(reportedPosts),
                         -8.4,
-                        "Fewer reports than last week",
-                        "Posts currently flagged by users"
+                        LocalizationProvider.getMessage("analytics.post.reported.message"),
+                        LocalizationProvider.getMessage("analytics.post.reported.description")
                 ),
                 new OverviewStatistic(
-                        "Avg. Engagement",
+                        LocalizationProvider.getMessage("analytics.post.avg_engagement.title"),
                         String.format("%.1f", avgEngagement),
                         5.9,
-                        "Up from last week",
-                        "Avg likes/comments per post (7d)"
+                        LocalizationProvider.getMessage("analytics.post.avg_engagement.message"),
+                        LocalizationProvider.getMessage("analytics.post.avg_engagement.description")
                 )
         );
     }

--- a/src/main/java/org/phong/horizon/analytics/services/TagAnalyticsService.java
+++ b/src/main/java/org/phong/horizon/analytics/services/TagAnalyticsService.java
@@ -3,6 +3,7 @@ package org.phong.horizon.analytics.services;
 import lombok.AllArgsConstructor;
 import org.phong.horizon.analytics.dtos.DailyCountDto;
 import org.phong.horizon.analytics.dtos.OverviewStatistic;
+import org.phong.horizon.core.services.LocalizationProvider;
 import org.phong.horizon.analytics.dtos.TopTagUsageDTO;
 import org.phong.horizon.analytics.projections.TopTagUsageProjection;
 import org.phong.horizon.post.subdomain.tag.entity.Tag;
@@ -54,32 +55,38 @@ public class TagAnalyticsService {
 
         return List.of(
             new OverviewStatistic(
-                "Total Tags",
+                LocalizationProvider.getMessage("analytics.tag.total.title"),
                 String.valueOf(totalTags),
                 tagTrend,
-                tagTrend > 0 ? "Growing" : "Stable",
-                "Total number of tags in the system"
+                tagTrend > 0
+                        ? LocalizationProvider.getMessage("analytics.tag.total.message.growing")
+                        : LocalizationProvider.getMessage("analytics.tag.total.message.stable"),
+                LocalizationProvider.getMessage("analytics.tag.total.description")
             ),
             new OverviewStatistic(
-                "Most Popular Tag",
+                LocalizationProvider.getMessage("analytics.tag.most_popular.title"),
                 mostUsedTagName,
                 0.0,
-                String.format("Used in %d posts", mostUsedTagCount),
-                "Tag with the most posts assigned"
+                LocalizationProvider.getMessage("analytics.tag.most_popular.message", mostUsedTagCount),
+                LocalizationProvider.getMessage("analytics.tag.most_popular.description")
             ),
             new OverviewStatistic(
-                "Unused Tags",
+                LocalizationProvider.getMessage("analytics.tag.unused.title"),
                 String.valueOf(unusedTags),
                 0.0,
-                unusedTags > 0 ? "Candidates for cleanup" : "All tags in use",
-                "Tags not used in any posts"
+                unusedTags > 0
+                        ? LocalizationProvider.getMessage("analytics.tag.unused.message.cleanup")
+                        : LocalizationProvider.getMessage("analytics.tag.unused.message.in_use"),
+                LocalizationProvider.getMessage("analytics.tag.unused.description")
             ),
             new OverviewStatistic(
-                "New Tags Today",
+                LocalizationProvider.getMessage("analytics.tag.new_today.title"),
                 String.valueOf(tagsToday),
                 tagTrend,
-                tagsToday > 0 ? "Active tag creation" : "No new tags today",
-                "Tags created in the last 24 hours"
+                tagsToday > 0
+                        ? LocalizationProvider.getMessage("analytics.tag.new_today.message.active")
+                        : LocalizationProvider.getMessage("analytics.tag.new_today.message.none"),
+                LocalizationProvider.getMessage("analytics.tag.new_today.description")
             )
         );
     }

--- a/src/main/java/org/phong/horizon/analytics/services/UserAnalyticsService.java
+++ b/src/main/java/org/phong/horizon/analytics/services/UserAnalyticsService.java
@@ -3,6 +3,7 @@ package org.phong.horizon.analytics.services;
 import lombok.AllArgsConstructor;
 import org.phong.horizon.analytics.dtos.OverviewStatistic;
 import org.phong.horizon.analytics.dtos.DailyCountDto;
+import org.phong.horizon.core.services.LocalizationProvider;
 import org.phong.horizon.user.infrastructure.persistence.repositories.UserRepository;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
@@ -47,32 +48,32 @@ public class UserAnalyticsService {
 
         return List.of(
                 new OverviewStatistic(
-                        "Total Users",
+                        LocalizationProvider.getMessage("analytics.user.total.title"),
                         String.valueOf(totalUsers),
                         userTrend,
-                        "Up 6.8% from last month",
-                        "Total registered users"
+                        LocalizationProvider.getMessage("analytics.user.total.message"),
+                        LocalizationProvider.getMessage("analytics.user.total.description")
                 ),
                 new OverviewStatistic(
-                        "New Users (30d)",
+                        LocalizationProvider.getMessage("analytics.user.new_30d.title"),
                         String.valueOf(newUsers30d),
                         2.3,
-                        "Steady onboarding rate",
-                        "Users signed up in the last 30 days"
+                        LocalizationProvider.getMessage("analytics.user.new_30d.message"),
+                        LocalizationProvider.getMessage("analytics.user.new_30d.description")
                 ),
                 new OverviewStatistic(
-                        "Banned Users",
+                        LocalizationProvider.getMessage("analytics.user.banned.title"),
                         String.valueOf(bannedUsers),
                         -5.0,
-                        "Decrease in bans",
-                        "Currently banned accounts"
+                        LocalizationProvider.getMessage("analytics.user.banned.message"),
+                        LocalizationProvider.getMessage("analytics.user.banned.description")
                 ),
                 new OverviewStatistic(
-                        "Verified Users",
+                        LocalizationProvider.getMessage("analytics.user.verified.title"),
                         String.valueOf(verifiedUsers),
                         12.1,
-                        "Verification requests rising",
-                        "Verified accounts to date"
+                        LocalizationProvider.getMessage("analytics.user.verified.message"),
+                        LocalizationProvider.getMessage("analytics.user.verified.description")
                 )
         );
     }

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -123,3 +123,150 @@ report.error.invalid_status_transition=Invalid status transition from %s to %s.
 
 admin.notification.error.not_found=Notification not found with id: %s
 admin.notification.error.invalid_data=Invalid notification data provided.
+# Analytics dashboard overview messages
+analytics.dashboard.total_users.title=Total Users
+analytics.dashboard.total_users.message.up=Up {0}% this month
+analytics.dashboard.total_users.message.down=Down {0}% this month
+analytics.dashboard.total_users.description=User growth over the last 30 days
+analytics.dashboard.total_posts.title=Total Posts
+analytics.dashboard.total_posts.message=Steady content creation
+analytics.dashboard.total_posts.description=Posts uploaded in the last 30 days
+analytics.dashboard.active_users.title=Active Users
+analytics.dashboard.active_users.message.high=High engagement this week
+analytics.dashboard.active_users.message.normal=Normal engagement levels
+analytics.dashboard.active_users.description=Users active in the last 7 days
+analytics.dashboard.pending_reports.title=Pending Reports
+analytics.dashboard.pending_reports.message.fewer=Fewer reports than last week
+analytics.dashboard.pending_reports.message.more=More reports than last week
+analytics.dashboard.pending_reports.description=Reports requiring admin review
+# Admin notification analytics messages
+analytics.admin_notifications.unread.title=Unread Notifications
+analytics.admin_notifications.unread.message.more=More unread items than yesterday
+analytics.admin_notifications.unread.message.fewer=Fewer unread items than yesterday
+analytics.admin_notifications.unread.description=Notifications requiring admin attention
+analytics.admin_notifications.critical.title=Critical Alerts
+analytics.admin_notifications.critical.message.more=Increase in critical alerts
+analytics.admin_notifications.critical.message.fewer=Decrease in critical alerts
+analytics.admin_notifications.critical.description=High priority notifications needing action
+analytics.admin_notifications.system_issues.title=System Issues (7d)
+analytics.admin_notifications.system_issues.message.more=More system issues than last week
+analytics.admin_notifications.system_issues.message.fewer=Fewer system issues than last week
+analytics.admin_notifications.system_issues.description=Errors and warnings from system in last 7 days
+analytics.admin_notifications.new_reports.title=New Reports (24h)
+analytics.admin_notifications.new_reports.message.increase=Increase in reports from previous day
+analytics.admin_notifications.new_reports.message.decrease=Decrease in reports from previous day
+analytics.admin_notifications.new_reports.description=User reports received in the last 24 hours
+
+# Category analytics messages
+analytics.category.total.title=Total Categories
+analytics.category.total.message.growing=Growing
+analytics.category.total.message.stable=Stable
+analytics.category.total.description=Total number of categories in the system
+analytics.category.most_used.title=Most Used Category
+analytics.category.most_used.message=Used in {0} posts
+analytics.category.most_used.description=Category with the most posts assigned
+analytics.category.unused.title=Unused Categories
+analytics.category.unused.message.cleanup=Candidates for cleanup
+analytics.category.unused.message.in_use=All categories in use
+analytics.category.unused.description=Categories without any posts
+analytics.category.new_today.title=New Categories Today
+analytics.category.new_today.message.active=Active category creation
+analytics.category.new_today.message.none=No new categories today
+analytics.category.new_today.description=Categories created in the last 24 hours
+
+# Comment analytics messages
+analytics.comment.total.title=Total Comments
+analytics.comment.total.message=Healthy engagement
+analytics.comment.total.description=All-time total comments
+analytics.comment.today.title=Comments Today
+analytics.comment.today.message.up=Up from yesterday
+analytics.comment.today.message.down=Down from yesterday
+analytics.comment.today.description=Activity in the past 24h
+analytics.comment.reported.title=Reported Comments
+analytics.comment.reported.message=Moderation load easing
+analytics.comment.reported.description=Comments flagged for review
+analytics.comment.avg_per_post.title=Avg. Comments/Post
+analytics.comment.avg_per_post.message=Steady interactions
+analytics.comment.avg_per_post.description=Engagement over the past 7 days
+
+# Log analytics messages
+analytics.log.errors_today.title=Error Logs Today
+analytics.log.errors_today.message.more=More errors than yesterday
+analytics.log.errors_today.message.fewer=Fewer errors than yesterday
+analytics.log.errors_today.description=Error-level logs recorded today
+analytics.log.critical_today.title=Critical Logs Today
+analytics.log.critical_today.message.more=More critical issues than yesterday
+analytics.log.critical_today.message.fewer=Fewer critical issues than yesterday
+analytics.log.critical_today.description=Critical-level logs recorded today
+analytics.log.errors_week.title=Error Logs (7d)
+analytics.log.errors_week.message.increase=Increase from previous week
+analytics.log.errors_week.message.decrease=Decrease from previous week
+analytics.log.errors_week.description=Total error logs in the last 7 days
+analytics.log.critical_week.title=Critical Logs (7d)
+analytics.log.critical_week.message.increase=Increase from previous week
+analytics.log.critical_week.message.decrease=Decrease from previous week
+analytics.log.critical_week.description=Total critical logs in the last 7 days
+
+# Moderation analytics messages
+analytics.moderation.pending.title=Pending Reports
+analytics.moderation.pending.message.fewer=Fewer reports than last week
+analytics.moderation.pending.message.more=More reports than last week
+analytics.moderation.pending.description=Reports requiring admin review
+analytics.moderation.resolved_today.title=Resolved Today
+analytics.moderation.resolved_today.message.more=More resolutions than yesterday
+analytics.moderation.resolved_today.message.fewer=Fewer resolutions than yesterday
+analytics.moderation.resolved_today.description=Reports actioned and resolved today
+analytics.moderation.content_removed.title=Content Removed (7d)
+analytics.moderation.content_removed.message.increase=Increase in content takedowns
+analytics.moderation.content_removed.message.decrease=Decrease in content takedowns
+analytics.moderation.content_removed.description=Posts/Comments removed in the last 7 days
+analytics.moderation.users_actioned.title=Users Actioned (7d)
+analytics.moderation.users_actioned.message.fewer=Fewer user actions this week
+analytics.moderation.users_actioned.message.more=More user actions this week
+analytics.moderation.users_actioned.description=Users warned or banned in the last 7 days
+
+# Post analytics messages
+analytics.post.total.title=Total Posts
+analytics.post.total.message=Steady content growth
+analytics.post.total.description=Total posts uploaded to date
+analytics.post.today.title=Posts Today
+analytics.post.today.message.up=Slight increase from yesterday
+analytics.post.today.message.down=Drop compared to yesterday
+analytics.post.today.description=Posts created in the last 24 hours
+analytics.post.reported.title=Reported Posts
+analytics.post.reported.message=Fewer reports than last week
+analytics.post.reported.description=Posts currently flagged by users
+analytics.post.avg_engagement.title=Avg. Engagement
+analytics.post.avg_engagement.message=Up from last week
+analytics.post.avg_engagement.description=Avg likes/comments per post (7d)
+
+# Tag analytics messages
+analytics.tag.total.title=Total Tags
+analytics.tag.total.message.growing=Growing
+analytics.tag.total.message.stable=Stable
+analytics.tag.total.description=Total number of tags in the system
+analytics.tag.most_popular.title=Most Popular Tag
+analytics.tag.most_popular.message=Used in {0} posts
+analytics.tag.most_popular.description=Tag with the most posts assigned
+analytics.tag.unused.title=Unused Tags
+analytics.tag.unused.message.cleanup=Candidates for cleanup
+analytics.tag.unused.message.in_use=All tags in use
+analytics.tag.unused.description=Tags not used in any posts
+analytics.tag.new_today.title=New Tags Today
+analytics.tag.new_today.message.active=Active tag creation
+analytics.tag.new_today.message.none=No new tags today
+analytics.tag.new_today.description=Tags created in the last 24 hours
+
+# User analytics messages
+analytics.user.total.title=Total Users
+analytics.user.total.message=Up 6.8% from last month
+analytics.user.total.description=Total registered users
+analytics.user.new_30d.title=New Users (30d)
+analytics.user.new_30d.message=Steady onboarding rate
+analytics.user.new_30d.description=Users signed up in the last 30 days
+analytics.user.banned.title=Banned Users
+analytics.user.banned.message=Decrease in bans
+analytics.user.banned.description=Currently banned accounts
+analytics.user.verified.title=Verified Users
+analytics.user.verified.message=Verification requests rising
+analytics.user.verified.description=Verified accounts to date

--- a/src/main/resources/messages_en.properties
+++ b/src/main/resources/messages_en.properties
@@ -123,3 +123,150 @@ report.error.invalid_status_transition=Invalid status transition from %s to %s.
 
 admin.notification.error.not_found=Notification not found with id: %s
 admin.notification.error.invalid_data=Invalid notification data provided.
+# Analytics dashboard overview messages
+analytics.dashboard.total_users.title=Total Users
+analytics.dashboard.total_users.message.up=Up {0}% this month
+analytics.dashboard.total_users.message.down=Down {0}% this month
+analytics.dashboard.total_users.description=User growth over the last 30 days
+analytics.dashboard.total_posts.title=Total Posts
+analytics.dashboard.total_posts.message=Steady content creation
+analytics.dashboard.total_posts.description=Posts uploaded in the last 30 days
+analytics.dashboard.active_users.title=Active Users
+analytics.dashboard.active_users.message.high=High engagement this week
+analytics.dashboard.active_users.message.normal=Normal engagement levels
+analytics.dashboard.active_users.description=Users active in the last 7 days
+analytics.dashboard.pending_reports.title=Pending Reports
+analytics.dashboard.pending_reports.message.fewer=Fewer reports than last week
+analytics.dashboard.pending_reports.message.more=More reports than last week
+analytics.dashboard.pending_reports.description=Reports requiring admin review
+# Admin notification analytics messages
+analytics.admin_notifications.unread.title=Unread Notifications
+analytics.admin_notifications.unread.message.more=More unread items than yesterday
+analytics.admin_notifications.unread.message.fewer=Fewer unread items than yesterday
+analytics.admin_notifications.unread.description=Notifications requiring admin attention
+analytics.admin_notifications.critical.title=Critical Alerts
+analytics.admin_notifications.critical.message.more=Increase in critical alerts
+analytics.admin_notifications.critical.message.fewer=Decrease in critical alerts
+analytics.admin_notifications.critical.description=High priority notifications needing action
+analytics.admin_notifications.system_issues.title=System Issues (7d)
+analytics.admin_notifications.system_issues.message.more=More system issues than last week
+analytics.admin_notifications.system_issues.message.fewer=Fewer system issues than last week
+analytics.admin_notifications.system_issues.description=Errors and warnings from system in last 7 days
+analytics.admin_notifications.new_reports.title=New Reports (24h)
+analytics.admin_notifications.new_reports.message.increase=Increase in reports from previous day
+analytics.admin_notifications.new_reports.message.decrease=Decrease in reports from previous day
+analytics.admin_notifications.new_reports.description=User reports received in the last 24 hours
+
+# Category analytics messages
+analytics.category.total.title=Total Categories
+analytics.category.total.message.growing=Growing
+analytics.category.total.message.stable=Stable
+analytics.category.total.description=Total number of categories in the system
+analytics.category.most_used.title=Most Used Category
+analytics.category.most_used.message=Used in {0} posts
+analytics.category.most_used.description=Category with the most posts assigned
+analytics.category.unused.title=Unused Categories
+analytics.category.unused.message.cleanup=Candidates for cleanup
+analytics.category.unused.message.in_use=All categories in use
+analytics.category.unused.description=Categories without any posts
+analytics.category.new_today.title=New Categories Today
+analytics.category.new_today.message.active=Active category creation
+analytics.category.new_today.message.none=No new categories today
+analytics.category.new_today.description=Categories created in the last 24 hours
+
+# Comment analytics messages
+analytics.comment.total.title=Total Comments
+analytics.comment.total.message=Healthy engagement
+analytics.comment.total.description=All-time total comments
+analytics.comment.today.title=Comments Today
+analytics.comment.today.message.up=Up from yesterday
+analytics.comment.today.message.down=Down from yesterday
+analytics.comment.today.description=Activity in the past 24h
+analytics.comment.reported.title=Reported Comments
+analytics.comment.reported.message=Moderation load easing
+analytics.comment.reported.description=Comments flagged for review
+analytics.comment.avg_per_post.title=Avg. Comments/Post
+analytics.comment.avg_per_post.message=Steady interactions
+analytics.comment.avg_per_post.description=Engagement over the past 7 days
+
+# Log analytics messages
+analytics.log.errors_today.title=Error Logs Today
+analytics.log.errors_today.message.more=More errors than yesterday
+analytics.log.errors_today.message.fewer=Fewer errors than yesterday
+analytics.log.errors_today.description=Error-level logs recorded today
+analytics.log.critical_today.title=Critical Logs Today
+analytics.log.critical_today.message.more=More critical issues than yesterday
+analytics.log.critical_today.message.fewer=Fewer critical issues than yesterday
+analytics.log.critical_today.description=Critical-level logs recorded today
+analytics.log.errors_week.title=Error Logs (7d)
+analytics.log.errors_week.message.increase=Increase from previous week
+analytics.log.errors_week.message.decrease=Decrease from previous week
+analytics.log.errors_week.description=Total error logs in the last 7 days
+analytics.log.critical_week.title=Critical Logs (7d)
+analytics.log.critical_week.message.increase=Increase from previous week
+analytics.log.critical_week.message.decrease=Decrease from previous week
+analytics.log.critical_week.description=Total critical logs in the last 7 days
+
+# Moderation analytics messages
+analytics.moderation.pending.title=Pending Reports
+analytics.moderation.pending.message.fewer=Fewer reports than last week
+analytics.moderation.pending.message.more=More reports than last week
+analytics.moderation.pending.description=Reports requiring admin review
+analytics.moderation.resolved_today.title=Resolved Today
+analytics.moderation.resolved_today.message.more=More resolutions than yesterday
+analytics.moderation.resolved_today.message.fewer=Fewer resolutions than yesterday
+analytics.moderation.resolved_today.description=Reports actioned and resolved today
+analytics.moderation.content_removed.title=Content Removed (7d)
+analytics.moderation.content_removed.message.increase=Increase in content takedowns
+analytics.moderation.content_removed.message.decrease=Decrease in content takedowns
+analytics.moderation.content_removed.description=Posts/Comments removed in the last 7 days
+analytics.moderation.users_actioned.title=Users Actioned (7d)
+analytics.moderation.users_actioned.message.fewer=Fewer user actions this week
+analytics.moderation.users_actioned.message.more=More user actions this week
+analytics.moderation.users_actioned.description=Users warned or banned in the last 7 days
+
+# Post analytics messages
+analytics.post.total.title=Total Posts
+analytics.post.total.message=Steady content growth
+analytics.post.total.description=Total posts uploaded to date
+analytics.post.today.title=Posts Today
+analytics.post.today.message.up=Slight increase from yesterday
+analytics.post.today.message.down=Drop compared to yesterday
+analytics.post.today.description=Posts created in the last 24 hours
+analytics.post.reported.title=Reported Posts
+analytics.post.reported.message=Fewer reports than last week
+analytics.post.reported.description=Posts currently flagged by users
+analytics.post.avg_engagement.title=Avg. Engagement
+analytics.post.avg_engagement.message=Up from last week
+analytics.post.avg_engagement.description=Avg likes/comments per post (7d)
+
+# Tag analytics messages
+analytics.tag.total.title=Total Tags
+analytics.tag.total.message.growing=Growing
+analytics.tag.total.message.stable=Stable
+analytics.tag.total.description=Total number of tags in the system
+analytics.tag.most_popular.title=Most Popular Tag
+analytics.tag.most_popular.message=Used in {0} posts
+analytics.tag.most_popular.description=Tag with the most posts assigned
+analytics.tag.unused.title=Unused Tags
+analytics.tag.unused.message.cleanup=Candidates for cleanup
+analytics.tag.unused.message.in_use=All tags in use
+analytics.tag.unused.description=Tags not used in any posts
+analytics.tag.new_today.title=New Tags Today
+analytics.tag.new_today.message.active=Active tag creation
+analytics.tag.new_today.message.none=No new tags today
+analytics.tag.new_today.description=Tags created in the last 24 hours
+
+# User analytics messages
+analytics.user.total.title=Total Users
+analytics.user.total.message=Up 6.8% from last month
+analytics.user.total.description=Total registered users
+analytics.user.new_30d.title=New Users (30d)
+analytics.user.new_30d.message=Steady onboarding rate
+analytics.user.new_30d.description=Users signed up in the last 30 days
+analytics.user.banned.title=Banned Users
+analytics.user.banned.message=Decrease in bans
+analytics.user.banned.description=Currently banned accounts
+analytics.user.verified.title=Verified Users
+analytics.user.verified.message=Verification requests rising
+analytics.user.verified.description=Verified accounts to date

--- a/src/main/resources/messages_vi.properties
+++ b/src/main/resources/messages_vi.properties
@@ -121,4 +121,150 @@ report.error.cannot_report_self=Không thể báo cáo chính mình.
 report.error.invalid_status_transition=Chuyển trạng thái từ %s sang %s không hợp lệ.
 
 admin.notification.error.not_found=Không tìm thấy thông báo id: %s
-admin.notification.error.invalid_data=Dữ liệu thông báo không hợp lệ.
+admin.notification.error.invalid_data=Dữ liệu thông báo không hợp lệ.# Analytics dashboard overview messages
+analytics.dashboard.total_users.title=Tổng người dùng
+analytics.dashboard.total_users.message.up=Tăng {0}% trong tháng này
+analytics.dashboard.total_users.message.down=Giảm {0}% trong tháng này
+analytics.dashboard.total_users.description=Số người dùng tăng trong 30 ngày qua
+analytics.dashboard.total_posts.title=Tổng bài viết
+analytics.dashboard.total_posts.message=Hoạt động đăng bài ổn định
+analytics.dashboard.total_posts.description=Số bài viết trong 30 ngày qua
+analytics.dashboard.active_users.title=Người dùng hoạt động
+analytics.dashboard.active_users.message.high=Độ tương tác cao tuần này
+analytics.dashboard.active_users.message.normal=Mức độ tương tác bình thường
+analytics.dashboard.active_users.description=Người dùng hoạt động trong 7 ngày qua
+analytics.dashboard.pending_reports.title=Báo cáo chờ xử lý
+analytics.dashboard.pending_reports.message.fewer=Ít báo cáo hơn tuần trước
+analytics.dashboard.pending_reports.message.more=Nhiều báo cáo hơn tuần trước
+analytics.dashboard.pending_reports.description=Báo cáo cần quản trị viên duyệt
+# Admin notification analytics messages
+analytics.admin_notifications.unread.title=Thông báo chưa đọc
+analytics.admin_notifications.unread.message.more=Nhiều thông báo chưa đọc hơn hôm qua
+analytics.admin_notifications.unread.message.fewer=Ít thông báo chưa đọc hơn hôm qua
+analytics.admin_notifications.unread.description=Thông báo cần quản trị viên xem
+analytics.admin_notifications.critical.title=Cảnh báo nghiêm trọng
+analytics.admin_notifications.critical.message.more=Tăng cảnh báo nghiêm trọng
+analytics.admin_notifications.critical.message.fewer=Giảm cảnh báo nghiêm trọng
+analytics.admin_notifications.critical.description=Thông báo ưu tiên cao cần xử lý
+analytics.admin_notifications.system_issues.title=Sự cố hệ thống (7 ngày)
+analytics.admin_notifications.system_issues.message.more=Nhiều sự cố hơn tuần trước
+analytics.admin_notifications.system_issues.message.fewer=Ít sự cố hơn tuần trước
+analytics.admin_notifications.system_issues.description=Lỗi và cảnh báo hệ thống trong 7 ngày qua
+analytics.admin_notifications.new_reports.title=Báo cáo mới (24h)
+analytics.admin_notifications.new_reports.message.increase=Tăng so với ngày trước
+analytics.admin_notifications.new_reports.message.decrease=Giảm so với ngày trước
+analytics.admin_notifications.new_reports.description=Báo cáo người dùng trong 24 giờ qua
+
+# Category analytics messages
+analytics.category.total.title=Tổng danh mục
+analytics.category.total.message.growing=Tăng trưởng
+analytics.category.total.message.stable=Ổn định
+analytics.category.total.description=Tổng số danh mục trong hệ thống
+analytics.category.most_used.title=Danh mục dùng nhiều nhất
+analytics.category.most_used.message=Được dùng trong {0} bài viết
+analytics.category.most_used.description=Danh mục có nhiều bài viết nhất
+analytics.category.unused.title=Danh mục không dùng
+analytics.category.unused.message.cleanup=Ứng viên để dọn dẹp
+analytics.category.unused.message.in_use=Tất cả danh mục đang dùng
+analytics.category.unused.description=Danh mục không có bài viết
+analytics.category.new_today.title=Danh mục mới hôm nay
+analytics.category.new_today.message.active=Tạo danh mục sôi động
+analytics.category.new_today.message.none=Hôm nay không có danh mục mới
+analytics.category.new_today.description=Danh mục tạo trong 24 giờ qua
+
+# Comment analytics messages
+analytics.comment.total.title=Tổng bình luận
+analytics.comment.total.message=Tương tác tốt
+analytics.comment.total.description=Tổng số bình luận từ trước đến nay
+analytics.comment.today.title=Bình luận hôm nay
+analytics.comment.today.message.up=Tăng so với hôm qua
+analytics.comment.today.message.down=Giảm so với hôm qua
+analytics.comment.today.description=Hoạt động trong 24 giờ qua
+analytics.comment.reported.title=Bình luận bị báo cáo
+analytics.comment.reported.message=Giảm tải kiểm duyệt
+analytics.comment.reported.description=Bình luận bị gắn cờ
+analytics.comment.avg_per_post.title=TB. bình luận/bài
+analytics.comment.avg_per_post.message=Tương tác ổn định
+analytics.comment.avg_per_post.description=Tương tác trong 7 ngày qua
+
+# Log analytics messages
+analytics.log.errors_today.title=Lỗi hôm nay
+analytics.log.errors_today.message.more=Nhiều lỗi hơn hôm qua
+analytics.log.errors_today.message.fewer=Ít lỗi hơn hôm qua
+analytics.log.errors_today.description=Log mức lỗi ghi nhận hôm nay
+analytics.log.critical_today.title=Lỗi nghiêm trọng hôm nay
+analytics.log.critical_today.message.more=Nhiều vấn đề nghiêm trọng hơn hôm qua
+analytics.log.critical_today.message.fewer=Ít vấn đề nghiêm trọng hơn hôm qua
+analytics.log.critical_today.description=Log mức nghiêm trọng ghi nhận hôm nay
+analytics.log.errors_week.title=Lỗi (7 ngày)
+analytics.log.errors_week.message.increase=Tăng so với tuần trước
+analytics.log.errors_week.message.decrease=Giảm so với tuần trước
+analytics.log.errors_week.description=Tổng số log lỗi 7 ngày qua
+analytics.log.critical_week.title=Lỗi nghiêm trọng (7 ngày)
+analytics.log.critical_week.message.increase=Tăng so với tuần trước
+analytics.log.critical_week.message.decrease=Giảm so với tuần trước
+analytics.log.critical_week.description=Tổng log nghiêm trọng 7 ngày qua
+
+# Moderation analytics messages
+analytics.moderation.pending.title=Báo cáo chờ xử lý
+analytics.moderation.pending.message.fewer=Ít báo cáo hơn tuần trước
+analytics.moderation.pending.message.more=Nhiều báo cáo hơn tuần trước
+analytics.moderation.pending.description=Báo cáo cần quản trị viên duyệt
+analytics.moderation.resolved_today.title=Đã xử lý hôm nay
+analytics.moderation.resolved_today.message.more=Xử lý nhiều hơn hôm qua
+analytics.moderation.resolved_today.message.fewer=Xử lý ít hơn hôm qua
+analytics.moderation.resolved_today.description=Báo cáo được xử lý hôm nay
+analytics.moderation.content_removed.title=Nội dung bị gỡ (7 ngày)
+analytics.moderation.content_removed.message.increase=Tăng số lần gỡ nội dung
+analytics.moderation.content_removed.message.decrease=Giảm số lần gỡ nội dung
+analytics.moderation.content_removed.description=Bài viết/bình luận bị gỡ trong 7 ngày
+analytics.moderation.users_actioned.title=Người dùng bị xử lý (7 ngày)
+analytics.moderation.users_actioned.message.fewer=Ít hành động hơn tuần trước
+analytics.moderation.users_actioned.message.more=Nhiều hành động hơn tuần trước
+analytics.moderation.users_actioned.description=Người dùng bị cảnh cáo hoặc cấm trong 7 ngày qua
+
+# Post analytics messages
+analytics.post.total.title=Tổng bài viết
+analytics.post.total.message=Tăng trưởng nội dung đều
+analytics.post.total.description=Tổng bài viết đã đăng
+analytics.post.today.title=Bài viết hôm nay
+analytics.post.today.message.up=Tăng nhẹ so với hôm qua
+analytics.post.today.message.down=Giảm so với hôm qua
+analytics.post.today.description=Bài viết tạo trong 24 giờ qua
+analytics.post.reported.title=Bài viết bị báo cáo
+analytics.post.reported.message=Ít báo cáo hơn tuần trước
+analytics.post.reported.description=Bài viết đang bị người dùng gắn cờ
+analytics.post.avg_engagement.title=Tương tác TB
+analytics.post.avg_engagement.message=Tăng so với tuần trước
+analytics.post.avg_engagement.description=Lượt thích/bình luận TB mỗi bài (7 ngày)
+
+# Tag analytics messages
+analytics.tag.total.title=Tổng thẻ
+analytics.tag.total.message.growing=Tăng trưởng
+analytics.tag.total.message.stable=Ổn định
+analytics.tag.total.description=Tổng số thẻ trong hệ thống
+analytics.tag.most_popular.title=Thẻ phổ biến nhất
+analytics.tag.most_popular.message=Được dùng trong {0} bài viết
+analytics.tag.most_popular.description=Thẻ có nhiều bài viết nhất
+analytics.tag.unused.title=Thẻ không dùng
+analytics.tag.unused.message.cleanup=Ứng viên để dọn dẹp
+analytics.tag.unused.message.in_use=Tất cả thẻ đang dùng
+analytics.tag.unused.description=Thẻ không xuất hiện trong bài nào
+analytics.tag.new_today.title=Thẻ mới hôm nay
+analytics.tag.new_today.message.active=Tạo thẻ sôi động
+analytics.tag.new_today.message.none=Hôm nay không có thẻ mới
+analytics.tag.new_today.description=Thẻ tạo trong 24 giờ qua
+
+# User analytics messages
+analytics.user.total.title=Tổng người dùng
+analytics.user.total.message=Tăng 6.8% so với tháng trước
+analytics.user.total.description=Tổng số người dùng đã đăng ký
+analytics.user.new_30d.title=Người dùng mới (30 ngày)
+analytics.user.new_30d.message=Tốc độ đăng ký ổn định
+analytics.user.new_30d.description=Người dùng đăng ký trong 30 ngày qua
+analytics.user.banned.title=Người dùng bị cấm
+analytics.user.banned.message=Giảm số lần cấm
+analytics.user.banned.description=Tài khoản đang bị cấm
+analytics.user.verified.title=Người dùng đã xác thực
+analytics.user.verified.message=Yêu cầu xác thực tăng
+analytics.user.verified.description=Tài khoản đã xác thực


### PR DESCRIPTION
## Summary
- add localization for dashboard analytics overview text
- supply message keys for dashboard analytics stats in all language bundles
- localize all analytics services

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_b_6853a75cd418832689f835ea3ff493f2